### PR TITLE
Wrap drift report in function and document cron usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # GPT_Code
+
+## 週次レポート
+
+`drift.py` は現在のポートフォリオのドリフトを計算し、Slack にレポートを送信するスクリプトです。
+
+### 手動実行 (CLI エントリポイント)
+
+環境変数 `SLACK_WEBHOOK_URL` を設定した上で、次のように実行できます。
+
+```bash
+python drift.py
+# またはモジュールとして
+python -m drift
+# もしくは関数を直接呼び出す
+python -c "from drift import weekly_report; weekly_report()"
+```
+
+### cron ジョブ例 (毎週月曜 9:00 実行)
+
+```
+0 9 * * MON export SLACK_WEBHOOK_URL=https://example.com && /usr/bin/python /path/to/drift.py
+```
+

--- a/drift.py
+++ b/drift.py
@@ -6,111 +6,117 @@ import os
 import csv
 from pathlib import Path
 
-# --- 1. ポートフォリオ定義 ---
-tickers_path = Path(__file__).with_name("current_tickers.csv")
-with tickers_path.open() as f:
-    reader = list(csv.reader(f))
-portfolio = [
-    {"symbol": sym.strip().upper(), "shares": int(qty), "target_ratio": 1/len(reader)}
-    for sym, qty in reader
-]
 
-# --- 2. VIX MA5 & 閾値設定 ---
-vix_ma5 = yf.Ticker("^VIX").history(period="7d")["Close"].tail(5).mean()
-drift_threshold = 10 if vix_ma5 < 20 else 12 if vix_ma5 < 26 else float("inf")
+def weekly_report():
+    # --- 1. ポートフォリオ定義 ---
+    tickers_path = Path(__file__).with_name("current_tickers.csv")
+    with tickers_path.open() as f:
+        reader = list(csv.reader(f))
+    portfolio = [
+        {"symbol": sym.strip().upper(), "shares": int(qty), "target_ratio": 1/len(reader)}
+        for sym, qty in reader
+    ]
 
-# --- 3. 株価取得＆ドリフト計算 ---
-for stock in portfolio:
-    try:
-        price = yf.Ticker(stock["symbol"]).history(period="1d")["Close"].iloc[-1]
-    except Exception:
-        price = 0
-    stock["price"] = price
-    stock["value"] = price * stock["shares"]
+    # --- 2. VIX MA5 & 閾値設定 ---
+    vix_ma5 = yf.Ticker("^VIX").history(period="7d")["Close"].tail(5).mean()
+    drift_threshold = 10 if vix_ma5 < 20 else 12 if vix_ma5 < 26 else float("inf")
 
-df = pd.DataFrame(portfolio)
-total_value        = df["value"].sum()
-df["current_ratio"] = df["value"] / total_value
-df["drift"]         = df["current_ratio"] - df["target_ratio"]
-df["drift_abs"]     = df["drift"].abs()
-total_drift_abs     = df["drift_abs"].sum()
+    # --- 3. 株価取得＆ドリフト計算 ---
+    for stock in portfolio:
+        try:
+            price = yf.Ticker(stock["symbol"]).history(period="1d")["Close"].iloc[-1]
+        except Exception:
+            price = 0
+        stock["price"] = price
+        stock["value"] = price * stock["shares"]
 
-# --- 4. 半戻し（ideal）計算 ---
-df["adjusted_ratio"] = df["current_ratio"] - df["drift"] / 2
-df["adjustable"]     = (df["adjusted_ratio"] * total_value) >= df["price"]
+    df = pd.DataFrame(portfolio)
+    total_value        = df["value"].sum()
+    df["current_ratio"] = df["value"] / total_value
+    df["drift"]         = df["current_ratio"] - df["target_ratio"]
+    df["drift_abs"]     = df["drift"].abs()
+    total_drift_abs     = df["drift_abs"].sum()
 
-# --- 5. 閾値超過時のみシミュレーション ---
-alert = drift_threshold != float("inf") and total_drift_abs * 100 > drift_threshold
-if alert:
-    df["trade_shares"] = df.apply(
-        lambda r: int(round(((r["adjusted_ratio"] * total_value) - r["value"]) / r["price"]))
-        if r["adjustable"] else 0,
-        axis=1
+    # --- 4. 半戻し（ideal）計算 ---
+    df["adjusted_ratio"] = df["current_ratio"] - df["drift"] / 2
+    df["adjustable"]     = (df["adjusted_ratio"] * total_value) >= df["price"]
+
+    # --- 5. 閾値超過時のみシミュレーション ---
+    alert = drift_threshold != float("inf") and total_drift_abs * 100 > drift_threshold
+    if alert:
+        df["trade_shares"] = df.apply(
+            lambda r: int(round(((r["adjusted_ratio"] * total_value) - r["value"]) / r["price"]))
+            if r["adjustable"] else 0,
+            axis=1
+        )
+        df["new_shares"]            = df["shares"] + df["trade_shares"]
+        df["new_value"]             = df["new_shares"] * df["price"]
+        new_total_value             = df["new_value"].sum()
+        df["simulated_ratio"]       = df["new_value"] / new_total_value
+        df["simulated_drift_abs"]   = (df["simulated_ratio"] - df["target_ratio"]).abs()
+        simulated_total_drift_abs   = df["simulated_drift_abs"].sum()
+    else:
+        df["trade_shares"]        = np.nan
+        simulated_total_drift_abs = np.nan
+
+    # --- 6. 合計行追加＆必要カラム抽出 ---
+    summary = {
+        "symbol":    "合計",
+        "shares":    df["shares"].sum(),
+        "value":     df["value"].sum(),
+        "current_ratio": np.nan,
+        "drift_abs": total_drift_abs,
+    }
+    if alert:
+        summary["trade_shares"] = np.nan
+
+    df = pd.concat([df, pd.DataFrame([summary])], ignore_index=True)
+
+    if alert:
+        cols = ["symbol", "shares", "value", "current_ratio", "drift_abs", "trade_shares"]
+        df_small = df[cols].copy()
+        df_small.columns = ["sym", "qty", "val", "now", "|d|", "Δqty"]
+    else:
+        cols = ["symbol", "shares", "value", "current_ratio", "drift_abs"]
+        df_small = df[cols].copy()
+        df_small.columns = ["sym", "qty", "val", "now", "|d|"]
+
+    # --- 7. 表示整形フォーマッタ ---
+    def currency(x): return f"${x:,.0f}" if pd.notnull(x) else ""
+    formatters = {
+        "val":    currency,
+        "now":    "{:.2%}".format,
+        "|d|":    "{:.2%}".format
+    }
+    if alert:
+        formatters["Δqty"] = "{:.0f}".format
+
+    # --- 8. Slack Incoming Webhook 送信（Secrets対応） ---
+    SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
+    if not SLACK_WEBHOOK_URL:
+        raise ValueError("SLACK_WEBHOOK_URL not set (環境変数が未設定です)")
+
+    header = (
+        f"*📈 VIX MA5:* {vix_ma5:.2f}\n"
+        f"*📊 ドリフト閾値:* {'🔴(高VIX)' if drift_threshold == float('inf') else str(drift_threshold)+'%'}\n"
+        f"*📉 現在のドリフト合計:* {total_drift_abs * 100:.2f}%\n"
     )
-    df["new_shares"]            = df["shares"] + df["trade_shares"]
-    df["new_value"]             = df["new_shares"] * df["price"]
-    new_total_value             = df["new_value"].sum()
-    df["simulated_ratio"]       = df["new_value"] / new_total_value
-    df["simulated_drift_abs"]   = (df["simulated_ratio"] - df["target_ratio"]).abs()
-    simulated_total_drift_abs   = df["simulated_drift_abs"].sum()
-else:
-    df["trade_shares"]        = np.nan
-    simulated_total_drift_abs = np.nan
+    if alert:
+        header += f"*🔁 実際のドリフト合計:* {simulated_total_drift_abs * 100:.2f}%\n"
+        header += "🚨 *アラート: 発生！！！！！！*\n"
+    else:
+        header += "✅ アラートなし\n"
 
-# --- 6. 合計行追加＆必要カラム抽出 ---
-summary = {
-    "symbol":    "合計",
-    "shares":    df["shares"].sum(),
-    "value":     df["value"].sum(),
-    "current_ratio": np.nan,
-    "drift_abs": total_drift_abs,
-}
-if alert:
-    summary["trade_shares"] = np.nan
+    table_text = df_small.to_string(formatters=formatters, index=False)
+    payload    = {"text": header + "\n```" + table_text + "```"}
 
-df = pd.concat([df, pd.DataFrame([summary])], ignore_index=True)
+    try:
+        resp = requests.post(SLACK_WEBHOOK_URL, json=payload)
+        resp.raise_for_status()
+        print("✅ Slack（Webhook）へ送信しました")
+    except Exception as e:
+        print(f"⚠️ Slack通知エラー: {e}")
 
-if alert:
-    cols = ["symbol", "shares", "value", "current_ratio", "drift_abs", "trade_shares"]
-    df_small = df[cols].copy()
-    df_small.columns = ["sym", "qty", "val", "now", "|d|", "Δqty"]
-else:
-    cols = ["symbol", "shares", "value", "current_ratio", "drift_abs"]
-    df_small = df[cols].copy()
-    df_small.columns = ["sym", "qty", "val", "now", "|d|"]
 
-# --- 7. 表示整形フォーマッタ ---
-def currency(x): return f"${x:,.0f}" if pd.notnull(x) else ""
-formatters = {
-    "val":    currency,
-    "now":    "{:.2%}".format,
-    "|d|":    "{:.2%}".format
-}
-if alert:
-    formatters["Δqty"] = "{:.0f}".format
-
-# --- 8. Slack Incoming Webhook 送信（Secrets対応） ---
-SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
-if not SLACK_WEBHOOK_URL:
-    raise ValueError("SLACK_WEBHOOK_URL not set (環境変数が未設定です)")
-
-header = (
-    f"*📈 VIX MA5:* {vix_ma5:.2f}\n"
-    f"*📊 ドリフト閾値:* {'🔴(高VIX)' if drift_threshold == float('inf') else str(drift_threshold)+'%'}\n"
-    f"*📉 現在のドリフト合計:* {total_drift_abs * 100:.2f}%\n"
-)
-if alert:
-    header += f"*🔁 実際のドリフト合計:* {simulated_total_drift_abs * 100:.2f}%\n"
-    header += "🚨 *アラート: 発生！！！！！！*\n"
-else:
-    header += "✅ アラートなし\n"
-
-table_text = df_small.to_string(formatters=formatters, index=False)
-payload    = {"text": header + "\n```" + table_text + "```"}
-
-try:
-    resp = requests.post(SLACK_WEBHOOK_URL, json=payload)
-    resp.raise_for_status()
-    print("✅ Slack（Webhook）へ送信しました")
-except Exception as e:
-    print(f"⚠️ Slack通知エラー: {e}")
+if __name__ == "__main__":
+    weekly_report()


### PR DESCRIPTION
## Summary
- wrap portfolio drift logic and Slack webhook into `weekly_report()`
- enable script execution via `if __name__ == '__main__': weekly_report()`
- document CLI entry points and cron job example for weekly runs

## Testing
- `python -m py_compile drift.py`
- `SLACK_WEBHOOK_URL=http://example.com python drift.py` *(fails: Failed to get ticker '^VIX' reason: Failed to perform, curl: (56) CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6893f17133cc832ea0b9b5ad4935b34f