### PR TITLE
Shorten performance metric keys

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -166,10 +166,10 @@ for name, ticks in portfolios.items():
     sharpe = ann_ret / ann_vol
     drawdown = (cum - cum.cummax()).min()
     metrics[name] = {
-        'Annual Return': ann_ret,
-        'Annual Vol': ann_vol,
-        'Sharpe': sharpe,
-        'Max DD': drawdown
+        'RET': ann_ret,
+        'VOL': ann_vol,
+        'SHP': sharpe,
+        'MDD': drawdown
     }
 
 df_metrics = pd.DataFrame(metrics).T


### PR DESCRIPTION
## Summary
- Use concise three-letter abbreviations (RET, VOL, SHP, MDD) for performance metrics

## Testing
- `python -m py_compile factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68940934d134832e86096f983500fba0