### PR TITLE
Handle Finnhub API errors gracefully

### DIFF
--- a/drift.py
+++ b/drift.py
@@ -25,8 +25,12 @@ def finnhub_get(endpoint, params):
         sleep_time = 60 - (now - call_times[0])
         time.sleep(sleep_time)
     params = {**params, "token": FINNHUB_API_KEY}
-    resp = requests.get(f"https://finnhub.io/api/v1/{endpoint}", params=params)
-    resp.raise_for_status()
+    try:
+        resp = requests.get(f"https://finnhub.io/api/v1/{endpoint}", params=params)
+        resp.raise_for_status()
+    except Exception as e:
+        print(f"⚠️ Finnhub API error: {e}")
+        return {}
     call_times.append(time.time())
     return resp.json()
 


### PR DESCRIPTION
## Summary
- prevent `drift.py` from crashing on Finnhub HTTP errors
- log API errors and fall back to empty data

## Testing
- `FINNHUB_API_KEY=dummy SLACK_WEBHOOK_URL=https://example.com python drift.py`


------
https://chatgpt.com/codex/tasks/task_e_6895ae961e4c832e851659dc41255666