### PR TITLE
Fix VIX MA5 retrieval for Finnhub data

### DIFF
--- a/drift.py
+++ b/drift.py
@@ -47,9 +47,11 @@ def fetch_vix_ma5():
     now = int(time.time())
     frm = now - 60 * 60 * 24 * 7
     data = finnhub_get(
-        "stock/candle",
+        "index/candle",
         {"symbol": "^VIX", "resolution": "D", "from": frm, "to": now},
     )
+    if data.get("s") != "ok":
+        return float("nan")
     closes = data.get("c", [])[-5:]
     return sum(closes) / len(closes) if closes else float("nan")
 


### PR DESCRIPTION
## Summary
- use Finnhub index candle endpoint to compute VIX 5-day moving average
- guard against missing data from Finnhub responses

## Testing
- `python -m py_compile drift.py`
- `FINNHUB_API_KEY=demo SLACK_WEBHOOK_URL=https://example.com python drift.py` *(fails: ProxyError connecting to finnhub.io)*

------
https://chatgpt.com/codex/tasks/task_e_6895b454b278832ea4cfdb90bb383d19