### PR TITLE
Gracefully handle Finnhub JSON decode errors

### DIFF
--- a/drift.py
+++ b/drift.py
@@ -28,11 +28,15 @@ def finnhub_get(endpoint, params):
     try:
         resp = requests.get(f"https://finnhub.io/api/v1/{endpoint}", params=params)
         resp.raise_for_status()
+        data = resp.json()
+    except requests.exceptions.JSONDecodeError as e:
+        print(f"⚠️ Finnhub API JSON decode error: {e}")
+        return {}
     except Exception as e:
         print(f"⚠️ Finnhub API error: {e}")
         return {}
     call_times.append(time.time())
-    return resp.json()
+    return data
 
 
 def fetch_price(symbol):


### PR DESCRIPTION
## Summary
- prevent drift script from crashing when Finnhub API returns invalid JSON

## Testing
- `python -m py_compile drift.py`
- `python drift.py` *(fails: FINNHUB_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_6895be7abebc832ebc130286b268f276