### PR TITLE
Switch factor analytics to Finnhub API

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
 
     steps:
       - name: Debug start


### PR DESCRIPTION
## Summary
- Use Finnhub API for factor screening with rate limiting
- Supply FINNHUB_API_KEY to weekly report workflow
- Guard relative strength and performance calculations against short price histories

## Testing
- `python -m py_compile factor.py`
- `FINNHUB_API_KEY=demo SLACK_WEBHOOK_URL=https://example.com python factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68960383c444832ea060d56e346ece91