### PR TITLE
Add inter-stock correlation metric to performance comparison

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -656,11 +656,17 @@ for name, ticks in portfolios.items():
         ann_vol = pr.std() * np.sqrt(n)
     sharpe = ann_ret / ann_vol
     drawdown = (cum - cum.cummax()).min()
+    if len(ticks) >= 2:
+        corr_mat = ret[ticks].corr()
+        avg_corr = corr_mat.mask(np.eye(len(ticks), dtype=bool)).stack().mean()
+    else:
+        avg_corr = np.nan
     metrics[name] = {
         'RET': ann_ret,
         'VOL': ann_vol,
         'SHP': sharpe,
-        'MDD': drawdown
+        'MDD': drawdown,
+        'CORR': avg_corr
     }
 
 df_metrics = pd.DataFrame(metrics).T


### PR DESCRIPTION
## Summary
- Compute average pairwise return correlation for each portfolio
- Include correlation metric in performance comparison output

## Testing
- `python -m py_compile factor.py`


------
https://chatgpt.com/codex/tasks/task_e_6898c1c0be24832e9b1e2c655f1dcbea