### PR TITLE
Refactor drift script for readability

### DIFF
--- a/drift.py
+++ b/drift.py
@@ -9,7 +9,6 @@ import yfinance as yf
 
 # Debug flag
 debug_mode = False  # set to True for detailed output
-debug_text = ""
 
 # --- Finnhub settings & helper ---
 FINNHUB_API_KEY = os.environ.get("FINNHUB_API_KEY")
@@ -67,134 +66,132 @@ def fetch_vix_ma5():
     except Exception:
         return float("nan")
 
-# --- 1. ポートフォリオ定義 ---
-tickers_path = Path(__file__).with_name("current_tickers.csv")
-with tickers_path.open() as f:
-    reader = list(csv.reader(f))
-portfolio = [
-    {"symbol": sym.strip().upper(), "shares": int(qty), "target_ratio": 1/len(reader)}
-    for sym, qty in reader
-]
 
-# --- 2. VIX MA5 & 閾値設定 ---
-vix_ma5 = fetch_vix_ma5()
-drift_threshold = 10 if vix_ma5 < 20 else 12 if vix_ma5 < 26 else float("inf")
-
-# --- 3. 株価取得＆ドリフト計算 ---
-for stock in portfolio:
-    price = fetch_price(stock["symbol"])
-    stock["price"] = price
-    stock["value"] = price * stock["shares"]
-
-df = pd.DataFrame(portfolio)
-total_value        = df["value"].sum()
-df["current_ratio"] = df["value"] / total_value
-df["drift"]         = df["current_ratio"] - df["target_ratio"]
-df["drift_abs"]     = df["drift"].abs()
-total_drift_abs     = df["drift_abs"].sum()
-
-# --- 4. 半戻し（ideal）計算 ---
-df["adjusted_ratio"] = df["current_ratio"] - df["drift"] / 2
-df["adjustable"]     = (
-    (df["adjusted_ratio"] * total_value) >= df["price"]
-    ) & df["price"].notna() & df["price"].gt(0)
-
-# --- 5. 閾値超過時のみシミュレーション ---
-alert = drift_threshold != float("inf") and total_drift_abs * 100 > drift_threshold
-if alert:
-    df["trade_shares"] = df.apply(
-        lambda r: int(round(((r["adjusted_ratio"] * total_value) - r["value"]) / r["price"]))
-        if r["adjustable"] and r["price"] > 0 else 0,
-        axis=1
-    )
-    df["new_shares"]            = df["shares"] + df["trade_shares"]
-    df["new_value"]             = df["new_shares"] * df["price"]
-    new_total_value             = df["new_value"].sum()
-    df["simulated_ratio"]       = df["new_value"] / new_total_value
-    df["simulated_drift_abs"]   = (df["simulated_ratio"] - df["target_ratio"]).abs()
-    simulated_total_drift_abs   = df["simulated_drift_abs"].sum()
-else:
-    df["trade_shares"]        = np.nan
-    df["new_shares"]         = np.nan
-    df["new_value"]          = np.nan
-    new_total_value          = np.nan
-    df["simulated_ratio"]    = np.nan
-    df["simulated_drift_abs"] = np.nan
-    simulated_total_drift_abs = np.nan
-
-if debug_mode:
-    debug_cols = [
-        "symbol", "shares", "price", "value", "current_ratio", "drift", "drift_abs",
-        "adjusted_ratio", "adjustable", "trade_shares", "new_shares", "new_value",
-        "simulated_ratio", "simulated_drift_abs"
+def load_portfolio():
+    tickers_path = Path(__file__).with_name("current_tickers.csv")
+    with tickers_path.open() as f:
+        reader = list(csv.reader(f))
+    return [
+        {"symbol": sym.strip().upper(), "shares": int(qty), "target_ratio": 1 / len(reader)}
+        for sym, qty in reader
     ]
-    debug_text = (
-        "=== DEBUG: full dataframe ===\n" +
-        df[debug_cols].to_string() +
-        f"\n\ntotal_value={total_value}, new_total_value={new_total_value}\n" +
-        f"total_drift_abs={total_drift_abs}, simulated_total_drift_abs={simulated_total_drift_abs}"
+
+
+def compute_threshold():
+    vix_ma5 = fetch_vix_ma5()
+    drift_threshold = 10 if vix_ma5 < 20 else 12 if vix_ma5 < 26 else float("inf")
+    return vix_ma5, drift_threshold
+
+
+def build_dataframe(portfolio):
+    for stock in portfolio:
+        price = fetch_price(stock["symbol"])
+        stock["price"] = price
+        stock["value"] = price * stock["shares"]
+
+    df = pd.DataFrame(portfolio)
+    total_value = df["value"].sum()
+    df["current_ratio"] = df["value"] / total_value
+    df["drift"] = df["current_ratio"] - df["target_ratio"]
+    df["drift_abs"] = df["drift"].abs()
+    total_drift_abs = df["drift_abs"].sum()
+    df["adjusted_ratio"] = df["current_ratio"] - df["drift"] / 2
+    df["adjustable"] = (
+        (df["adjusted_ratio"] * total_value) >= df["price"]
+    ) & df["price"].notna() & df["price"].gt(0)
+    return df, total_value, total_drift_abs
+
+
+def simulate(df, total_value, total_drift_abs, drift_threshold):
+    alert = drift_threshold != float("inf") and total_drift_abs * 100 > drift_threshold
+    if alert:
+        df["trade_shares"] = df.apply(
+            lambda r: int(round(((r["adjusted_ratio"] * total_value) - r["value"]) / r["price"]))
+            if r["adjustable"] and r["price"] > 0 else 0,
+            axis=1,
+        )
+        df["new_shares"] = df["shares"] + df["trade_shares"]
+        df["new_value"] = df["new_shares"] * df["price"]
+        new_total_value = df["new_value"].sum()
+        df["simulated_ratio"] = df["new_value"] / new_total_value
+        df["simulated_drift_abs"] = (df["simulated_ratio"] - df["target_ratio"]).abs()
+        simulated_total_drift_abs = df["simulated_drift_abs"].sum()
+    else:
+        df["trade_shares"] = np.nan
+        df["new_shares"] = np.nan
+        df["new_value"] = np.nan
+        new_total_value = np.nan
+        df["simulated_ratio"] = np.nan
+        df["simulated_drift_abs"] = np.nan
+        simulated_total_drift_abs = np.nan
+    return df, alert, new_total_value, simulated_total_drift_abs
+
+
+def prepare_summary(df, total_drift_abs, alert):
+    summary = {
+        "symbol": "合計",
+        "shares": df["shares"].sum(),
+        "value": df["value"].sum(),
+        "current_ratio": np.nan,
+        "drift_abs": total_drift_abs,
+    }
+    if alert:
+        summary["trade_shares"] = np.nan
+
+    df = pd.concat([df, pd.DataFrame([summary])], ignore_index=True)
+    if alert:
+        cols = ["symbol", "shares", "value", "current_ratio", "drift_abs", "trade_shares"]
+        df_small = df[cols].copy()
+        df_small.columns = ["sym", "qty", "val", "now", "|d|", "Δqty"]
+    else:
+        cols = ["symbol", "shares", "value", "current_ratio", "drift_abs"]
+        df_small = df[cols].copy()
+        df_small.columns = ["sym", "qty", "val", "now", "|d|"]
+    return df_small
+
+
+def currency(x):
+    return f"${x:,.0f}" if pd.notnull(x) else ""
+
+
+def formatters_for(alert):
+    formatters = {"val": currency, "now": "{:.2%}".format, "|d|": "{:.2%}".format}
+    if alert:
+        formatters["Δqty"] = "{:.0f}".format
+    return formatters
+
+
+def build_header(vix_ma5, drift_threshold, total_drift_abs, alert, simulated_total_drift_abs):
+    header = (
+        f"*📈 VIX MA5:* {vix_ma5:.2f}\n"
+        f"*📊 ドリフト閾値:* {'🔴(高VIX)' if drift_threshold == float('inf') else str(drift_threshold)+'%'}\n"
+        f"*📉 現在のドリフト合計:* {total_drift_abs * 100:.2f}%\n"
     )
-    print("\n" + debug_text)
+    if alert:
+        header += f"*🔁 半戻し後ドリフト合計(想定):* {simulated_total_drift_abs * 100:.2f}%\n"
+        header += "🚨 *アラート: 発生！！ Δqtyのマイナス銘柄を売却、任意の銘柄を買い増してバランスを取りましょう！*\n"
+    else:
+        header += "✅ アラートなし\n"
+    return header
 
-# --- 6. 合計行追加＆必要カラム抽出 ---
-summary = {
-    "symbol":    "合計",
-    "shares":    df["shares"].sum(),
-    "value":     df["value"].sum(),
-    "current_ratio": np.nan,
-    "drift_abs": total_drift_abs,
-}
-if alert:
-    summary["trade_shares"] = np.nan
 
-df = pd.concat([df, pd.DataFrame([summary])], ignore_index=True)
+def send_slack(text):
+    SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
+    if not SLACK_WEBHOOK_URL:
+        raise ValueError("SLACK_WEBHOOK_URL not set (環境変数が未設定です)")
+    payload = {"text": text}
+    try:
+        resp = requests.post(SLACK_WEBHOOK_URL, json=payload)
+        resp.raise_for_status()
+        print("✅ Slack（Webhook）へ送信しました")
+    except Exception as e:
+        print(f"⚠️ Slack通知エラー: {e}")
 
-if alert:
-    cols = ["symbol", "shares", "value", "current_ratio", "drift_abs", "trade_shares"]
-    df_small = df[cols].copy()
-    df_small.columns = ["sym", "qty", "val", "now", "|d|", "Δqty"]
-else:
-    cols = ["symbol", "shares", "value", "current_ratio", "drift_abs"]
-    df_small = df[cols].copy()
-    df_small.columns = ["sym", "qty", "val", "now", "|d|"]
 
-# --- 7. 表示整形フォーマッタ ---
-def currency(x): return f"${x:,.0f}" if pd.notnull(x) else ""
-formatters = {
-    "val":    currency,
-    "now":    "{:.2%}".format,
-    "|d|":    "{:.2%}".format
-}
-if alert:
-    formatters["Δqty"] = "{:.0f}".format
-
-# --- 8. Slack Incoming Webhook 送信（Secrets対応） ---
-SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
-if not SLACK_WEBHOOK_URL:
-    raise ValueError("SLACK_WEBHOOK_URL not set (環境変数が未設定です)")
-
-header = (
-    f"*📈 VIX MA5:* {vix_ma5:.2f}\n"
-    f"*📊 ドリフト閾値:* {'🔴(高VIX)' if drift_threshold == float('inf') else str(drift_threshold)+'%'}\n"
-    f"*📉 現在のドリフト合計:* {total_drift_abs * 100:.2f}%\n"
-)
-if alert:
-    header += f"*🔁 半戻し後ドリフト合計(想定):* {simulated_total_drift_abs * 100:.2f}%\n"
-    header += "🚨 *アラート: 発生！！ Δqtyのマイナス銘柄を売却、任意の銘柄を買い増してバランスを取りましょう！*\n"
-else:
-    header += "✅ アラートなし\n"
-
-table_text = df_small.to_string(formatters=formatters, index=False)
-payload    = {"text": header + "\n```" + table_text + "```"}
-
-try:
-    resp = requests.post(SLACK_WEBHOOK_URL, json=payload)
-    resp.raise_for_status()
-    print("✅ Slack（Webhook）へ送信しました")
-except Exception as e:
-    print(f"⚠️ Slack通知エラー: {e}")
-
-if debug_mode:
+def send_debug(debug_text):
+    SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
+    if not SLACK_WEBHOOK_URL:
+        raise ValueError("SLACK_WEBHOOK_URL not set (環境変数が未設定です)")
     debug_payload = {"text": "```" + debug_text + "```"}
     try:
         resp = requests.post(SLACK_WEBHOOK_URL, json=debug_payload)
@@ -202,3 +199,50 @@ if debug_mode:
         print("✅ Debug情報をSlackに送信しました")
     except Exception as e:
         print(f"⚠️ Slack通知エラー: {e}")
+
+
+def main():
+    portfolio = load_portfolio()
+    vix_ma5, drift_threshold = compute_threshold()
+    df, total_value, total_drift_abs = build_dataframe(portfolio)
+    df, alert, new_total_value, simulated_total_drift_abs = simulate(
+        df, total_value, total_drift_abs, drift_threshold
+    )
+    df_small = prepare_summary(df, total_drift_abs, alert)
+    formatters = formatters_for(alert)
+    header = build_header(
+        vix_ma5, drift_threshold, total_drift_abs, alert, simulated_total_drift_abs
+    )
+    table_text = df_small.to_string(formatters=formatters, index=False)
+    send_slack(header + "\n```" + table_text + "```")
+
+    if debug_mode:
+        debug_cols = [
+            "symbol",
+            "shares",
+            "price",
+            "value",
+            "current_ratio",
+            "drift",
+            "drift_abs",
+            "adjusted_ratio",
+            "adjustable",
+            "trade_shares",
+            "new_shares",
+            "new_value",
+            "simulated_ratio",
+            "simulated_drift_abs",
+        ]
+        debug_text = (
+            "=== DEBUG: full dataframe ===\n"
+            + df[debug_cols].to_string()
+            + f"\n\ntotal_value={total_value}, new_total_value={new_total_value}\n"
+            + f"total_drift_abs={total_drift_abs}, simulated_total_drift_abs={simulated_total_drift_abs}"
+        )
+        print("\n" + debug_text)
+        send_debug(debug_text)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- refactor drift drift.py to organize logic into functions and orchestrate in a `main` block for clearer execution flow

## Testing
- `python -m py_compile drift.py factor.py`

------
https://chatgpt.com/codex/tasks/task_e_689bef68aed4832e82e01b0ebb9cd3c6