### PR TITLE
Sort factor tables and ensure full pre-filter scores

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -589,9 +589,11 @@ class Scorer:
 
         # 全銘柄（初期ユニバース）の index を確定
         universe = sorted(set(g_score_all.index) | set(d_score_all.index))
-        scores_full = pd.DataFrame(index=universe)
-        scores_full["GSC"] = g_score_all.reindex(universe)
-        scores_full["DSC"] = d_score_all.reindex(universe)
+        G_full = g_score_all.reindex(universe).astype(float)
+        D_full = d_score_all.reindex(universe).astype(float)
+        G_full = G_full.fillna(0.0)
+        D_full = D_full.fillna(0.0)
+        scores_full = pd.DataFrame({"GSC": G_full, "DSC": D_full}, index=universe)
 
         feat = FeatureBundle(
             df=df,


### PR DESCRIPTION
## Summary
- Preserve pre-filter GSC/DSC for all tickers and fill missing scores
- Sort G and D bucket outputs by their scores to maintain ranking
- Display change list using full pre-filter scores with validation

## Testing
- `python -m py_compile scorer.py factor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a41396c320832ebcfb9a6f32d74f1f