### PR TITLE
Add growth entry flags and G-report Slack message

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -28,6 +28,8 @@
 
 import os, json, time, requests
 import numpy as np, pandas as pd, yfinance as yf
+import pandas as pd
+import numpy as np
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 from scipy.stats import zscore
@@ -574,6 +576,10 @@ class Scorer:
             _base = d_comp.mul(dw, axis=1).sum(axis=1)
             _test = d_comp.assign(VOL=d_comp['VOL'] + eps).mul(dw, axis=1).sum(axis=1)
             print("VOL増→d_score低下の比率:", ((_test <= _base) | _test.isna() | _base.isna()).mean())
+        try:
+            df = _apply_growth_entry_flags(df, ib, self, win_breakout=5, win_pullback=5)
+        except Exception:
+            pass
 
         return FeatureBundle(
             df=df,
@@ -582,6 +588,99 @@ class Scorer:
             d_score_all=d_score_all,
             missing_logs=pd.DataFrame(missing_logs)
         )
+
+
+def _apply_growth_entry_flags(feature_df, bundle, self_obj, win_breakout=5, win_pullback=5):
+    """
+    G枠ユニバースに対し、ブレイクアウト確定/押し目反発の「直近N営業日内の発火」を判定し、
+    次の列を feature_df に追加する（index=ticker）。
+      - G_BREAKOUT_recent_5d : bool
+      - G_BREAKOUT_last_date : str "YYYY-MM-DD"
+      - G_PULLBACK_recent_5d : bool
+      - G_PULLBACK_last_date : str "YYYY-MM-DD"
+      - G_PIVOT_price        : float
+    失敗しても例外は握り潰し、既存処理を阻害しない。
+    """
+    try:
+        px   = bundle.px                      # 終値 DataFrame
+        hi   = bundle.data['High']
+        lo   = bundle.data['Low']
+        vol  = bundle.data['Volume']
+        bench= bundle.spx                     # ベンチマーク Series
+
+        # Gユニバース推定：self.g_universe 優先 → feature_df['group']=='G' → 全銘柄
+        g_universe = getattr(self_obj, "g_universe", None)
+        if g_universe is None:
+            try:
+                g_universe = feature_df.index[feature_df['group'].astype(str).str.upper().eq('G')].tolist()
+            except Exception:
+                g_universe = list(feature_df.index)
+        if not g_universe:
+            return feature_df
+
+        # 指標
+        ema21 = px[g_universe].ewm(span=21, adjust=False).mean()
+        ma50  = px[g_universe].rolling(50).mean()
+        ma150 = px[g_universe].rolling(150).mean()
+        ma200 = px[g_universe].rolling(200).mean()
+        atr20 = (hi[g_universe] - lo[g_universe]).rolling(20).mean()
+        vol20 = vol[g_universe].rolling(20).mean()
+        vol50 = vol[g_universe].rolling(50).mean()
+
+        # トレンドテンプレート合格
+        trend_template_ok = (px[g_universe] > ma50) & (px[g_universe] > ma150) & (px[g_universe] > ma200) \
+                            & (ma150 > ma200) & (ma200.diff() > 0)
+
+        # 汎用ピボット：直近65営業日の高値（当日除外）
+        pivot_price = hi[g_universe].rolling(65).max().shift(1)
+
+        # 相対力：年内高値更新
+        bench_aligned = bench.reindex(px.index).ffill()
+        rs = px[g_universe].div(bench_aligned, axis=0)
+        rs_high = rs.rolling(252).max().shift(1)
+
+        # ブレイクアウト「発生日」：条件立ち上がり
+        breakout_today = trend_template_ok & (px[g_universe] > pivot_price) \
+                         & (vol[g_universe] >= 1.5 * vol50) & (rs > rs_high)
+        breakout_event = breakout_today & ~breakout_today.shift(1).fillna(False)
+
+        # 押し目反発「発生日」：EMA21帯×出来高ドライアップ×前日高値越え×終値EMA21上
+        near_ema21_band = px[g_universe].between(ema21 - atr20, ema21 + atr20)
+        volume_dryup = (vol20 / vol50) <= 1.0
+        pullback_bounce_confirmed = (px[g_universe] > hi[g_universe].shift(1)) & (px[g_universe] > ema21)
+        pullback_today = trend_template_ok & near_ema21_band & volume_dryup & pullback_bounce_confirmed
+        pullback_event = pullback_today & ~pullback_today.shift(1).fillna(False)
+
+        # 直近N営業日内の発火 / 最終発生日
+        rows = []
+        for t in g_universe:
+            def _recent_and_date(s, win):
+                sw = s[t].iloc[-win:]
+                if sw.any():
+                    d = sw[sw].index[-1]
+                    return True, d.strftime("%Y-%m-%d")
+                return False, ""
+            br_recent, br_date = _recent_and_date(breakout_event, win_breakout)
+            pb_recent, pb_date = _recent_and_date(pullback_event, win_pullback)
+            rows.append((t, {
+                "G_BREAKOUT_recent_5d": br_recent,
+                "G_BREAKOUT_last_date": br_date,
+                "G_PULLBACK_recent_5d": pb_recent,
+                "G_PULLBACK_last_date": pb_date,
+                "G_PIVOT_price": float(pivot_price[t].iloc[-1]) if t in pivot_price.columns else float('nan'),
+            }))
+        flags = pd.DataFrame({k: v for k, v in rows}).T
+
+        # 列を作成・上書き
+        cols = ["G_BREAKOUT_recent_5d","G_BREAKOUT_last_date","G_PULLBACK_recent_5d","G_PULLBACK_last_date","G_PIVOT_price"]
+        for c in cols:
+            if c not in feature_df.columns:
+                feature_df[c] = np.nan
+        feature_df.loc[flags.index, flags.columns] = flags
+
+    except Exception:
+        pass
+    return feature_df
 
 
 # === 単体実行サンプル（最小） =================================================


### PR DESCRIPTION
## Summary
- track recent breakout and pullback events with `_apply_growth_entry_flags`
- notify Slack with G-frame weekly report including fire indicators

## Testing
- `python -m py_compile scorer.py factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a551c8b744832e9beebee1074374b1