### PR TITLE
Adjust default D weights

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -13,7 +13,7 @@ CAND_PRICE_MAX, bench = 400, '^GSPC'  # 価格上限・ベンチマーク
 N_G, N_D = 12, 13  # G/D枠サイズ
 g_weights = {'GRW':0.40,'MOM':0.40,'TRD':0.00,'VOL':-0.20}
 D_BETA_MAX = float(os.environ.get("D_BETA_MAX", "0.9"))
-D_weights = {'QAL':0.1,'YLD':0.25,'VOL':-0.4,'TRD':0.25}
+D_weights = {'QAL':0.15,'YLD':0.15,'VOL':-0.45,'TRD':0.25}
 
 # DRRS 初期プール・各種パラメータ
 corrM = 45

--- a/scorer.py
+++ b/scorer.py
@@ -96,7 +96,7 @@ class PipelineConfig:
 
 # ---- デフォルト設定（外部が渡せばそれを優先） -------------------------------
 DEFAULT_G_WEIGHTS = {'GRW':0.40,'MOM':0.40,'TRD':0.00,'VOL':-0.20}
-DEFAULT_D_WEIGHTS = {'QAL':0.10,'YLD':0.25,'VOL':-0.40,'TRD':0.25}
+DEFAULT_D_WEIGHTS = {'QAL':0.15,'YLD':0.15,'VOL':-0.45,'TRD':0.25}
 DEFAULT_DRRS = DRRSParams(
     corrM=45, shrink=0.10,
     G=dict(lookback=252, n_pc=3, gamma=1.2, lam=0.68, eta=0.8),


### PR DESCRIPTION
## Summary
- tune default D weights for scoring pipeline
- align factor module D weights with new defaults

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66705ee38832eb3e52a14d1217fd6