### PR TITLE
refactor: centralize D filter

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -567,9 +567,10 @@ class Scorer:
         df_z['DSC'] = d_score_all
 
         # --- D枠のβフィルタ（採用可視化） ---
-        d_pass_beta = df['BETA'] < D_BETA_MAX
-        df_z['D_PASS_BETA'] = d_pass_beta.astype(float)          # 1/0 フラグ
-        df_z['DSC_DPASS']   = d_score_all.where(d_pass_beta, np.nan)  # β基準未満は NaN
+        # removed: beta gate moved to factor.py
+        # d_pass_beta = df['BETA'] < D_BETA_MAX
+        # df_z['D_PASS_BETA'] = d_pass_beta.astype(float)
+        # df_z['DSC_DPASS']   = d_score_all.where(d_pass_beta, np.nan)
 
         if debug_mode:
             eps = 0.1


### PR DESCRIPTION
## Summary
- centralize D bucket prefilter into factor module using configurable thresholds for beta, growth and debt-to-equity
- drop redundant beta gate from scorer to avoid double filtering
- route selection through new pre-filtered candidate list

## Testing
- `python -m py_compile factor.py scorer.py`

------
https://chatgpt.com/codex/tasks/task_e_68abfaccc398832e957155b90e0b0291