### PR TITLE
chore: add role guard comment and scorer adapter

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -1,3 +1,15 @@
+"""
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ ROLE of factor.py                                     ┃
+┃  - Orchestration ONLY                                 ┃
+┃  - I/O (CSV/API/ENV/Slack) & SSOT constants           ┃
+┃  - Slack formatting/output                            ┃
+┃ DO NOT: implement scoring/filters/DRRS here           ┃
+┃ IF REQUEST says:                                      ┃
+┃   •「スコア/フィルタ/相関低減を変更」→ scorer.py へ   ┃
+┃   •「Slack文言/見た目/JSON保存」→ ここ（factor.py）  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+"""
 # === NOTE: 機能・入出力・ログ文言・例外挙動は不変。安全な短縮（import統合/複数代入/内包表記/メソッドチェーン/一行化/空行圧縮など）のみ適用 ===
 import yfinance as yf, pandas as pd, numpy as np, os, requests, time, json
 from scipy.stats import zscore


### PR DESCRIPTION
## Summary
- document orchestration responsibilities at the top of factor.py
- append a non-I/O adapter layer in scorer.py that delegates to existing implementations

## Testing
- `python factor.py` *(fails: Finnhub API key not provided)*
- `python -m py_compile factor.py scorer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad2030f3e0832e9ff98cc0fc258d58