### PR TITLE
refactor: clean scorer utilities and reorder Slack sections

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -528,10 +528,10 @@ class Output:
         message += self.g_title + "\n```" + self.g_table.to_string(formatters=self.g_formatters) + "```\n"
         message += self.d_title + "\n```" + self.d_table.to_string(formatters=self.d_formatters) + "```\n"
         message += "Changes\n```" + self.io_table.to_string(index=False) + "```\n"
+        message += "Performance Comparison:\n```" + self.df_metrics_fmt.to_string() + "```"
         # 低スコアTOP10（GSC+DSC）
         if self.low10_table is not None:
-            message += "Low Score Candidates (GSC+DSC bottom 10)\n```" + self.low10_table.to_string() + "```\n"
-        message += "Performance Comparison:\n```" + self.df_metrics_fmt.to_string() + "```"
+            message += "\nLow Score Candidates (GSC+DSC bottom 10)\n```" + self.low10_table.to_string() + "```\n"
         if self.debug and self.debug_table is not None: message += "\nDebug Data\n```" + self.debug_table.to_string() + "```"
         payload = {"text": message}
         try:


### PR DESCRIPTION
## Summary
- remove CLI, env and standalone execution logic from scorer utility
- send performance comparison before low score candidates in Slack output

## Testing
- `python -m py_compile scorer.py factor.py`
- `python factor.py` *(fails: ProxyError 'CONNECT tunnel failed')*

------
https://chatgpt.com/codex/tasks/task_e_68ad3337c500832e8b78091f6a5e2341