### PR TITLE
Add filter spec and adjust beta threshold

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -20,7 +20,8 @@ exist, cand = [pd.read_csv(f, header=None)[0].tolist() for f in ("current_ticker
 CAND_PRICE_MAX, bench = 400, '^GSPC'  # 価格上限・ベンチマーク
 N_G, N_D = 12, 13  # G/D枠サイズ
 g_weights = {'GRW':0.40,'MOM':0.40,'TRD':0.00,'VOL':-0.20}
-D_BETA_MAX = float(os.environ.get("D_BETA_MAX", "0.9"))
+D_BETA_MAX = float(os.environ.get("D_BETA_MAX", "0.8"))
+FILTER_SPEC = {"G":{"pre_mask":["trend_template"]},"D":{"pre_filter":{"beta_max":D_BETA_MAX}}}
 D_weights = {'QAL':0.15,'YLD':0.15,'VOL':-0.45,'TRD':0.25}
 
 # DRRS 初期プール・各種パラメータ


### PR DESCRIPTION
## Summary
- Reduce `D_BETA_MAX` default to 0.8
- Introduce `FILTER_SPEC` for pre-mask and pre-filter configuration

## Testing
- `pytest -q`
- `python -m py_compile factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad9c6bd500832ebb53af6d0706ee07