### PR TITLE
Optimize Finnhub fallback

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -41,4 +41,5 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+          FIN_THREADS: "8"
         run: python factor.py


### PR DESCRIPTION
## Summary
- log tickers with missing Yahoo Finance financials and fetch Finnhub only for those symbols
- allow factor.py parallelism tuning via FIN_THREADS env in workflow

## Testing
- `python -m py_compile factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae4d153eb4832e9b17d80d4cb5de9c