### PR TITLE
Clip price history to DRRS window

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -322,6 +322,10 @@ class Input:
         data = yf.download(tickers + [self.bench], period="600d", auto_adjust=True, progress=False)
         T.log("yf.download done")
         px, spx = data["Close"], data["Close"][self.bench]
+        need = max(DRRS_G["lookback"], DRRS_D["lookback"]) + 10  # safety buffer
+        px  = px.tail(need + 1)   # pct_change用に +1 本
+        spx = spx.tail(need + 1)
+        print(f"[T] price window clipped to {len(px)} rows")
         tickers_bulk, info = yf.Tickers(" ".join(tickers)), {}
         for t in tickers:
             try: info[t] = tickers_bulk.tickers[t].info


### PR DESCRIPTION
## Summary
- Trim downloaded price series to max DRRS lookback plus safety buffer before computing returns.
- Log final window size for verification.

## Testing
- `python -m py_compile factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae578de510832ea7da2a53d8c87106