### PR TITLE
Enable pip cache in weekly workflow

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -19,9 +19,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.x'                # （必要最小限のまま。固定したければ '3.13'）
+          cache: 'pip'                         # ★ pipキャッシュを有効化
+          cache-dependency-path: requirements.txt  # ★ 依存ファイルをキャッシュキーに
 
       - name: Install dependencies
         run: pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- use `actions/setup-python@v5` in weekly workflow
- enable pip caching based on `requirements.txt`

## Testing
- `python -m py_compile drift.py factor.py scorer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae630f13fc832e9cf0f6e180143fea