### PR TITLE
feat: cache yfinance financials and optimize price filter

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -39,9 +39,32 @@ jobs:
           restore-keys: |
             results-
 
+      - name: Compute quarter key (UTC)
+        shell: bash
+        run: |
+          q=$(( (($(date -u +%-m)+2)/3) ))
+          echo "YF_CACHE_QTR=$(date -u +%Y)Q$q" >> $GITHUB_ENV
+
+      - name: Cache YF financials
+        uses: actions/cache@v3
+        with:
+          path: .cache/yf_fin
+          key: yf-fin-${{ env.YF_CACHE_QTR }}
+          restore-keys: |
+            yf-fin-
+
+      - name: Speed knobs (env)
+        shell: bash
+        run: |
+          echo "FIN_THREADS=16" >> $GITHUB_ENV
+          echo "CACHE_DIR=.cache" >> $GITHUB_ENV
+          echo "YF_FIN_TTL_DAYS=90" >> $GITHUB_ENV
+
       - name: Run factor.py
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
-          FIN_THREADS: "8"
+          FIN_THREADS: "16"
+          CACHE_DIR: ".cache"
+          YF_FIN_TTL_DAYS: "90"
         run: python factor.py


### PR DESCRIPTION
## Summary
- add simple JSON-based cache for yfinance financial data
- move candidate price cap filtering to post-download close prices
- persist financial cache and speed knobs in weekly report workflow

## Testing
- `python -m py_compile factor.py`
- `SLACK_WEBHOOK_URL=https://httpbin.org/post FINNHUB_API_KEY=dummy FIN_THREADS=2 PRICE_CLIP_DAYS=0 YF_FIN_TTL_DAYS=0 CACHE_DIR=.cache python factor.py 2>&1 | head -n 20` *(fails: CONNECT tunnel failed 403)*
- `SLACK_WEBHOOK_URL=https://httpbin.org/post FINNHUB_API_KEY=dummy FIN_THREADS=2 PRICE_CLIP_DAYS=0 YF_FIN_TTL_DAYS=0 CACHE_DIR=.cache python factor.py 2>&1 | tail -n 20` *(fails: single positional indexer is out-of-bounds)*

------
https://chatgpt.com/codex/tasks/task_e_68ae72bb5134832e829601f5a5b3f9ff