### PR TITLE
Optimize z-score standardization with vectorized DataFrame ops

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -45,6 +45,21 @@ def winsorize_s(s: pd.Series, p=0.02):
 def robust_z(s: pd.Series, p=0.02):
     s2 = winsorize_s(s, p); return np.nan_to_num(zscore(s2.fillna(s2.mean())))
 
+def robust_z_df(df: pd.DataFrame, p=0.02) -> pd.DataFrame:
+    """列ごとの winsorize→zscore を DataFrame一括で（robust_zと数値一致）。"""
+    if df is None or df.empty: return df
+    A = df.to_numpy(dtype=float, copy=True)
+    lo = np.nanpercentile(A, 100*p, axis=0); hi = np.nanpercentile(A, 100*(1-p), axis=0)
+    A = np.clip(A, lo, hi)
+    m = np.nanmean(A, axis=0)
+    mask = np.isnan(A)
+    if mask.any():
+        A[mask] = np.take(m, np.nonzero(mask)[1])
+    sd = np.nanstd(A, axis=0, ddof=0)
+    sd[sd==0] = np.nan
+    Z = (A - m) / sd
+    return pd.DataFrame(np.nan_to_num(Z), index=df.index, columns=df.columns)
+
 def _safe_div(a, b):
     try:
         if b is None or float(b)==0 or pd.isna(b): return np.nan
@@ -427,14 +442,19 @@ class Scorer:
         # === Z化と合成 ===
         for col in ['ROE','FCF','REV','EPS']: df[f'{col}_W'] = winsorize_s(df[col], 0.02)
 
-        df_z = pd.DataFrame(index=df.index)
-        for col in ['EPS','REV','ROE','FCF','RS','TR_str','BETA','DIV','DIV_STREAK']: df_z[col] = robust_z(df[col])
-        df_z['REV'], df_z['EPS'], df_z['TR'] = robust_z(df['REV_W']), robust_z(df['EPS_W']), robust_z(df['TR'])
-        for col in ['P_OVER_150','P_OVER_200','MA50_OVER_200','MA200_SLOPE_5M','LOW52PCT25_EXCESS','NEAR_52W_HIGH','RS_SLOPE_6W','RS_SLOPE_13W','MA200_UP_STREAK_D']: df_z[col] = robust_z(df[col])
-        for col in ['REV_Q_YOY','EPS_Q_YOY','REV_YOY_ACC','REV_YOY_VAR','FCF_MGN','RULE40','REV_ANN_STREAK']: df_z[col] = robust_z(df[col])
-        for col in ['DOWNSIDE_DEV','MDD_1Y','RESID_VOL','DOWN_OUTPERF','EXT_200','DIV_TTM_PS','DIV_VAR5','DIV_YOY','DIV_FCF_COVER','DEBT2EQ','CURR_RATIO','EPS_VAR_8Q','MARKET_CAP','ADV60_USD']: df_z[col] = robust_z(df[col])
+        cols = ['EPS','REV','ROE','FCF','RS','TR_str','BETA','DIV','DIV_STREAK',
+                'REV_W','EPS_W','TR','P_OVER_150','P_OVER_200','MA50_OVER_200','MA200_SLOPE_5M',
+                'LOW52PCT25_EXCESS','NEAR_52W_HIGH','RS_SLOPE_6W','RS_SLOPE_13W','MA200_UP_STREAK_D',
+                'REV_Q_YOY','EPS_Q_YOY','REV_YOY_ACC','REV_YOY_VAR','FCF_MGN','RULE40','REV_ANN_STREAK',
+                'DOWNSIDE_DEV','MDD_1Y','RESID_VOL','DOWN_OUTPERF','EXT_200','DIV_TTM_PS','DIV_VAR5',
+                'DIV_YOY','DIV_FCF_COVER','DEBT2EQ','CURR_RATIO','EPS_VAR_8Q','MARKET_CAP','ADV60_USD']
+        df_z = robust_z_df(df[cols])
+        df_z.rename(columns={'REV_W':'REV','EPS_W':'EPS'}, inplace=True)
 
-        df_z['SIZE'], df_z['LIQ'] = robust_z(np.log1p(df['MARKET_CAP'])), robust_z(np.log1p(df['ADV60_USD']))
+        df_z[['SIZE','LIQ']] = robust_z_df(pd.DataFrame({
+            'SIZE': np.log1p(df['MARKET_CAP']),
+            'LIQ':  np.log1p(df['ADV60_USD'])
+        }, index=df.index))
         df_z['QUALITY_F'] = robust_z(0.6*df['FCF_W'] + 0.4*df['ROE_W']).clip(-3.0,3.0)
         df_z['YIELD_F']   = 0.3*df_z['DIV'] + 0.7*df_z['DIV_STREAK']
         df_z['GROWTH_F']  = robust_z(
@@ -455,10 +475,9 @@ class Scorer:
             + 0.10*df_z['MA200_SLOPE_5M']
             + 0.10*df_z['MA200_UP_STREAK_D']
         ).clip(-3.0,3.0)
-        df_z['VOL'] = robust_z(df['BETA'])
+        df_z['VOL'] = df_z['BETA']
         df_z.rename(columns={'GROWTH_F':'GRW','MOM_F':'MOM','QUALITY_F':'QAL','YIELD_F':'YLD'}, inplace=True)
         df_z['TRD'] = 0.0  # TRDはスコア寄与から外し、テンプレ判定はフィルタで行う（列は表示互換のため残す）
-        if 'BETA' not in df_z.columns: df_z['BETA'] = robust_z(df['BETA'])
 
         df_z['D_VOL_RAW'] = robust_z(0.40*df_z['DOWNSIDE_DEV'] + 0.22*df_z['RESID_VOL'] + 0.18*df_z['MDD_1Y'] - 0.10*df_z['DOWN_OUTPERF'] - 0.05*df_z['EXT_200'] - 0.08*df_z['SIZE'] - 0.10*df_z['LIQ'] + 0.10*df_z['BETA'])
         df_z['D_QAL']     = robust_z(0.35*df_z['QAL'] + 0.20*df_z['FCF'] + 0.15*df_z['CURR_RATIO'] - 0.15*df_z['DEBT2EQ'] - 0.15*df_z['EPS_VAR_8Q'])


### PR DESCRIPTION
## Summary
- add `robust_z_df` for bulk winsorize+zscore matching `robust_z`
- replace per-column z-score loops with single `robust_z_df` call and share BETA result for VOL
- vectorize SIZE/LIQ standardization

## Testing
- `python - <<'PY'
import pandas as pd, numpy as np
from scorer import robust_z_df, robust_z
np.random.seed(0)
A = pd.DataFrame(np.random.randn(100,5), columns=list('ABCDE'))
A.iloc[0,0] = np.nan
z_loop = A.apply(robust_z)
z_df = robust_z_df(A)
print('max diff', (z_loop - z_df).abs().max().max())
PY`
- `python - <<'PY'
import pandas as pd
import numpy as np
import yfinance as yf
from factor import Input, InputBundle, PipelineConfig, WeightsConfig, DRRSParams, Scorer, g_weights, D_weights, corrM, DRRS_G, DRRS_D, DRRS_SHRINK, CROSS_MU_GD, CAND_PRICE_MAX, bench
cand = []
exist = ['AAPL','MSFT','GOOGL']
inp = Input(cand=cand, exist=exist, bench=bench, price_max=CAND_PRICE_MAX)
try:
    state = inp.prepare_data()
    ib = InputBundle(
        cand=state['cand'], tickers=state['tickers'], bench=bench,
        data=state['data'], px=state['px'], spx=state['spx'],
        tickers_bulk=state['tickers_bulk'], info=state['info'],
        eps_df=state['eps_df'], fcf_df=state['fcf_df'], returns=state['returns']
    )
    cfg = PipelineConfig(
        weights=WeightsConfig(g=g_weights, d=D_weights),
        drrs=DRRSParams(corrM=corrM, shrink=DRRS_SHRINK, G=DRRS_G, D=DRRS_D, cross_mu_gd=CROSS_MU_GD),
        price_max=CAND_PRICE_MAX
    )
    sc = Scorer()
    fb = sc.aggregate_scores(ib, cfg)
    print('df shape', fb.df.shape, 'df_z shape', fb.df_z.shape)
except Exception as e:
    print('aggregate_scores failed:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aeef5b844c832eba36f2abbe62868e