### PR TITLE
Add Minervini sell signal alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Changelog
 
 - Documented near-miss tracking and DSC fallback in Slack output.
+- Added Minervini-like sell signal scan with Slack highlighting.


### PR DESCRIPTION
## Summary
- scan portfolio for Minervini-style sell signals via yfinance
- flag tickers in drift table and prepend alert column
- replace header text with sell-signal warning when signals detected

## Testing
- `python -m py_compile drift.py`
- `python drift.py` *(fails: FINNHUB_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_68afa7edba40832ebec8113c779264bd