### PR TITLE
Remove TRD weight and generate trend template feature

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -34,7 +34,7 @@ exist, cand = [pd.read_csv(f, header=None)[0].tolist() for f in ("current_ticker
 T.log(f"csv loaded: exist={len(exist)} cand={len(cand)}")
 CAND_PRICE_MAX, bench = 400, '^GSPC'  # 価格上限・ベンチマーク
 N_G, N_D = 12, 13  # G/D枠サイズ
-g_weights = {'GRW':0.40,'MOM':0.40,'TRD':0.00,'VOL':-0.20}
+g_weights = {'GRW':0.40,'MOM':0.40,'VOL':-0.20}
 D_BETA_MAX = float(os.environ.get("D_BETA_MAX", "0.8"))
 FILTER_SPEC = {"G":{"pre_mask":["trend_template"]},"D":{"pre_filter":{"beta_max":D_BETA_MAX}}}
 D_weights = {'QAL':0.15,'YLD':0.15,'VOL':-0.45,'TRD':0.25}


### PR DESCRIPTION
## Summary
- drop unused TRD factor from G weights
- always generate trend_template feature and reuse it for masking

## Testing
- `python -m py_compile factor.py scorer.py`
- `python factor.py` *(fails: Finnhub API key not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68afb7d236f0832e9fb1258fc49139d1