### PR TITLE
Ensure D features included and hide TRD in Slack G table

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -198,6 +198,7 @@ class Scorer:
 
         px, spx, tickers = ib.px, ib.spx, ib.tickers
         tickers_bulk, info, eps_df, fcf_df = ib.tickers_bulk, ib.info, ib.eps_df, ib.fcf_df
+        families = set(getattr(cfg.weights, 'g', {})) | set(getattr(cfg.weights, 'd', {}))
 
         df, missing_logs = pd.DataFrame(index=tickers), []
         for t in tickers:


### PR DESCRIPTION
## Summary
- include D-family keys when determining factor families
- hide TRD column from Slack G table while keeping D table unchanged

## Testing
- `python -m py_compile scorer.py factor.py`
- `python factor.py` *(fails: Finnhub API key not provided)*
- `python - <<'PY'
import pandas as pd, os, types
import factor, requests

class DummyResp:
    def raise_for_status(self): pass

def fake_post(url, json):
    print('URL:', url)
    print('MSG:\n'+json['text'])
    return DummyResp()
requests.post = fake_post

os.environ['SLACK_WEBHOOK_URL'] = 'http://example.com'

out = factor.Output()
out.miss_df = pd.DataFrame()
out.g_title = 'G'
out.g_table = pd.DataFrame({'GRW':[1.1],'MOM':[2.2],'TRD':[0.0],'VOL':[3.3]}, index=['AAA'])
out.g_formatters = {'GRW':"{:.1f}".format,'MOM':"{:.1f}".format,'TRD':"{:.1f}".format,'VOL':"{:.1f}".format}
out.d_title = 'D'
out.d_table = pd.DataFrame({'QAL':[0.5],'YLD':[0.6],'VOL':[0.7],'TRD':[0.0]}, index=['BBB'])
out.d_formatters = {'QAL':"{:.1f}".format,'YLD':"{:.1f}".format,'VOL':"{:.1f}".format,'TRD':"{:.1f}".format}
out.io_table = pd.DataFrame({'a':[1]})
out.df_metrics_fmt = pd.DataFrame({'RET':['1%']})
out.low10_table = None
out.debug = False
out.notify_slack()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68afbdb5358c832eab1f4d7754c26f30