### PR TITLE
fix: handle TRD family and slack output

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -198,7 +198,7 @@ class Scorer:
 
         px, spx, tickers = ib.px, ib.spx, ib.tickers
         tickers_bulk, info, eps_df, fcf_df = ib.tickers_bulk, ib.info, ib.eps_df, ib.fcf_df
-        families = set(getattr(cfg.weights, 'g', {})) | set(getattr(cfg.weights, 'd', {}))
+        families = set(getattr(cfg.weights,'g',{})|getattr(cfg.weights,'d',{}))
 
         df, missing_logs = pd.DataFrame(index=tickers), []
         for t in tickers:


### PR DESCRIPTION
## Summary
- ensure factor families include D weights
- hide TRD column in G slack block and handle empty Changes block
- build slack headers from weight dicts so unused weights like TRD are omitted

## Testing
- `python -m py_compile factor.py scorer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc0cd6d74832eba96b059176438bd