### PR TITLE
feat: show filter spec in Slack titles

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -198,7 +198,7 @@ class Scorer:
 
         px, spx, tickers = ib.px, ib.spx, ib.tickers
         tickers_bulk, info, eps_df, fcf_df = ib.tickers_bulk, ib.info, ib.eps_df, ib.fcf_df
-        families = set(getattr(cfg.weights,'g',{})|getattr(cfg.weights,'d',{}))
+        families = set(getattr(cfg.weights,'g',{})) | set(getattr(cfg.weights,'d',{}))
 
         df, missing_logs = pd.DataFrame(index=tickers), []
         for t in tickers:


### PR DESCRIPTION
## Summary
- include D-weight families when collecting scorer stats
- add filter descriptions and safe table handling in Slack output

## Testing
- `python -m py_compile scorer.py factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68afc7dc9aa8832e8f2357abdd564d75