### PR TITLE
Wrap low-score table in Slack code block

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -955,7 +955,10 @@ def run_pipeline() -> SelectionBundle:
               .head(10)
               .round(3)
         )
-        _slack("Low Score Candidates (GSC+DSC bottom 10)\n" + _low_df.to_string())
+        _slack(
+            "Low Score Candidates (GSC+DSC bottom 10)\n"
+            + "```" + _low_df.to_string(index=False) + "```"
+        )
     except Exception as _e:
         _slack(f"Low Score Candidates: 作成失敗: {_e}")
 


### PR DESCRIPTION
## Summary
- Format low-score candidates Slack message as code block and hide index

## Testing
- `python -m py_compile factor.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90758d028832e9b970af926851130