### PR TITLE
Append CSV mirror to low score Slack message

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -955,10 +955,11 @@ def run_pipeline() -> SelectionBundle:
               .head(10)
               .round(3)
         )
-        _slack(
-            "Low Score Candidates (GSC+DSC bottom 10)\n"
-            + "```" + _low_df.to_string(index=False) + "```"
-        )
+        _slack("```Low Score Candidates (GSC+DSC bottom 10)\n"
+               + _low_df.rename_axis("TICKER").reset_index().to_string(index=False)
+               + "\n```"
+               + "\n\n[COPY]\n"
+               + _low_df.rename_axis("TICKER").reset_index().to_csv(index=False))
         if os.getenv("LOW_SCORE_MIRROR", "0") == "1":
             _slack("Low Score Candidates (GSC+DSC bottom 10)\n"
                    + _low_df.rename_axis("TICKER").to_string())


### PR DESCRIPTION
## Summary
- Include CSV mirror alongside code-block table in low score candidates Slack message for easy mobile copy

## Testing
- `python -m py_compile factor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b921eb0144832e9d344c4ac7a7c0e9