### PR TITLE
chore(chat): one-tap copy page

### DIFF
--- a/.github/workflows/prepare-chat-pack.yml
+++ b/.github/workflows/prepare-chat-pack.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
       - name: Build chat-pack.txt (single file)
         run: |
           python -m pip install --upgrade pip
@@ -29,6 +30,53 @@ jobs:
           git commit -m "chore(chat): update chat-pack.txt" || echo "no changes"
           git push
 
+      # \u25bc \u3053\u3053\u304b\u3089\u8ffd\u52a0\uff1a\u30ef\u30f3\u30bf\u30c3\u30d7\u30b3\u30d4\u30fc\u7528\u306e HTML \u3092\u751f\u6210\u3057\u3066\u30b3\u30df\u30c3\u30c8
+      - name: Build one-tap copy page (docs/chat-pack.html)
+        run: |
+          mkdir -p docs
+          python - <<'PY'
+import pathlib
+txt = pathlib.Path('chat_build/chat-pack.txt').read_text(encoding='utf-8')
+# JS\u306e\u30c6\u30f3\u30d7\u30ec\u30fc\u30c8\u30ea\u30c6\u30e9\u30eb\u306b\u5b89\u5168\u306b\u57cb\u3081\u8fbc\u3080\u7c21\u6613\u30a8\u30b9\u30b1\u30fc\u30d7
+esc = txt.replace('\\', '\\\\').replace('`','\\`')
+html_page = f"""<!doctype html><meta charset=\"utf-8\"><meta name=viewport content=\"width=device-width,initial-scale=1\">
+<title>Chat Pack \u2013 One Tap Copy</title>
+<style>
+  body{{font-family:-apple-system,system-ui,Segoe UI,Roboto; margin:16px; line-height:1.5}}
+  button{{font-size:18px; padding:12px 16px;}}
+  textarea{{width:100%; height:70vh; margin-top:12px; font-family:ui-monospace,Menlo,monospace}}
+  .note{{color:#555; font-size:14px}}
+</style>
+<h1>Chat Pack</h1>
+<p class=note>\u4e0b\u306e\u30dc\u30bf\u30f3\u3067 <b>\u5168\u30b3\u30d4\u30fc</b> \u3067\u304d\u307e\u3059\u3002iPhone/Safari/\u30a2\u30d7\u30ea\u3067\u52d5\u4f5c\u3002\u30b3\u30d4\u30fc\u3067\u304d\u306a\u3044\u5834\u5408\u306f\u30c6\u30ad\u30b9\u30c8\u6bb5\u3092\u9577\u62bc\u3057\u2192\u300c\u3059\u3079\u3066\u9078\u629e\u2192\u30b3\u30d4\u30fc\u300d\u3002</p>
+<button id=\"copy\">\u5168\u30b3\u30d4\u30fc</button>
+<textarea id=\"box\" readonly></textarea>
+<script>
+const content = `""" + esc + """`;
+const box = document.getElementById('box'); box.value = content;
+document.getElementById('copy').onclick = async () => {
+  try {
+    await navigator.clipboard.writeText(content);
+    alert('\u30b3\u30d4\u30fc\u3057\u307e\u3057\u305f');
+  } catch (e) {
+    box.select(); document.execCommand('copy'); // \u53e4\u3044iOS\u5411\u3051\u30d5\u30a9\u30fc\u30eb\u30d0\u30c3\u30af
+    alert('\u30b3\u30d4\u30fc\u3057\u307e\u3057\u305f\uff08\u30d5\u30a9\u30fc\u30eb\u30d0\u30c3\u30af\uff09');
+  }
+};
+</script>
+"""
+pathlib.Path('docs/chat-pack.html').write_text(html_page, encoding='utf-8')
+PY
+
+      - name: Commit one-tap copy page
+        run: |
+          git config user.name "chat-pack-bot"
+          git config user.email "bot@users.noreply.github.com"
+          git add docs/chat-pack.html
+          git commit -m "feat(chat): add one-tap copy page (docs/chat-pack.html)" || echo "no changes"
+          git push
+
+      # Job Summary \u306b\u30d7\u30ec\u30d3\u30e5\u30fc\uff08~1MB\u307e\u3067\uff09
       - name: Print chat-pack into Job Summary (with truncation)
         run: |
           MAX=$((1024*1024 - 4096))
@@ -39,6 +87,11 @@ jobs:
             cat chat_build/chat-pack.txt >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           else
-            echo "_Truncated (file > ~1MB). Open the committed file instead._" >> $GITHUB_STEP_SUMMARY
+            echo "_Truncated (file > ~1MB). Open docs/chat-pack.html to copy._" >> $GITHUB_STEP_SUMMARY
           fi
 
+      # \uff08\u4efb\u610f\uff09Artifacts\u3082\u6b32\u3057\u3051\u308c\u3070\u30b3\u30e1\u30f3\u30c8\u30a2\u30a6\u30c8\89e3\u9664
+      # - uses: actions/upload-artifact@v4
+      #   with:
+      #     name: chat-paste-pack
+      #     path: chat_build/chat-pack.txt


### PR DESCRIPTION
## Summary
- extend chat pack workflow to build docs/chat-pack.html with one-tap copy support

## Testing
- `python -m py_compile tools/make_chat_pack.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68ba2925c1fc832ea6f2594883bc6c4f