### PR TITLE
refactor: drop legacy hysteresis state

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -29,14 +29,6 @@ jobs:
       - name: Prepare results directory
         run: mkdir -p results
 
-      - name: Cache previous results
-        uses: actions/cache@v3
-        with:
-          path: results
-          key: results-${{ github.run_id }}
-          restore-keys: |
-            results-
-
       - name: Run drift.py
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -31,15 +31,7 @@ jobs:
       - name: Prepare results directory
         run: mkdir -p results
 
-      - name: Cache previous results
-        uses: actions/cache@v3
-        with:
-          path: results
-          key: results-${{ github.run_id }}
-          restore-keys: |
-            results-
-
-      - name: Run factor.py
+      - name: Run factor & scoring
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}


### PR DESCRIPTION
## Summary
- centralize BONUS_COEFF in factor orchestrator
- drop prev-json hysteresis logic and related caching steps
- add dynamic bonus loading in scorer and streamline report workflows

## Testing
- `python -m py_compile factor.py scorer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba492183b0832eaecb063f1fe1622e