### PR TITLE
Fix G score ordering bug in run_group

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -779,6 +779,9 @@ def run_group(sc: Scorer, group: str, inb: InputBundle, cfg: PipelineConfig,
         if group == "D" and hasattr(fb, "df"):
             agg = agg[fb.df['BETA'] < D_BETA_MAX]
 
+    # ---- ② スコア Series を group 判定ごとに処理 ----
+    agg = agg.sort_values(ascending=False)  # ★ NEW: スコアを必ず降順に並べ替え
+
     if hasattr(sc, "filter_candidates"):
         mask = sc.filter_candidates(inb, agg, group, cfg)
         agg = agg[mask]


### PR DESCRIPTION
## Summary
- Ensure aggregated score series are sorted in descending order within `run_group`
- Keeps existing theme penalty configuration unchanged

## Testing
- `timeout 90s python factor.py` *(fails: Finnhub API key not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68bab0531bec832e9b9bb5684070d6d1