### PR TITLE
refactor: drop unused utilities and variable

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -110,22 +110,7 @@ class PipelineConfig:
 
 
 # ===== 共通ユーティリティ（複数クラスで使用） =====
-def winsorize_s(s: pd.Series, p=0.02):
-    if s is None or s.dropna().empty: return s
-    lo, hi = np.nanpercentile(s.astype(float), [100*p, 100*(1-p)]); return s.clip(lo, hi)
-
-def robust_z(s: pd.Series, p=0.02):
-    s2 = winsorize_s(s, p); return np.nan_to_num(zscore(s2.fillna(s2.mean())))
-
-def _safe_div(a, b):
-    try:
-        if b is None or float(b)==0 or pd.isna(b): return np.nan
-        return float(a)/float(b)
-    except Exception: return np.nan
-
-def _safe_last(series: pd.Series, default=np.nan):
-    try: return float(series.iloc[-1])
-    except Exception: return default
+# (unused local utils removed – use scorer.py versions if needed)
 
 def _env_true(name: str, default=False):
     v = os.getenv(name)

--- a/scorer.py
+++ b/scorer.py
@@ -278,7 +278,6 @@ class Scorer:
 
         px, spx, tickers = ib.px, ib.spx, ib.tickers
         tickers_bulk, info, eps_df, fcf_df = ib.tickers_bulk, ib.info, ib.eps_df, ib.fcf_df
-        families = set(getattr(cfg.weights,'g',{})) | set(getattr(cfg.weights,'d',{}))
 
         df, missing_logs = pd.DataFrame(index=tickers), []
         for t in tickers:


### PR DESCRIPTION
## Summary
- remove unused helper utilities from `factor.py`
- drop unused `families` variable in `Scorer.aggregate_scores`

## Testing
- ⚠️ `python factor.py` *(fails: curl 403 errors and IndexError)*
- ⚠️ `pylint --disable=all --enable=unused-variable factor.py scorer.py` *(fails: pylint not installed; proxy prevents installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bac5d1190c832eab8a86b74014c3a1