### PR TITLE
chore(chat): add CodeForChat pack generator and workflow

### DIFF
--- a/.github/workflows/prepare-chat-pack.yml
+++ b/.github/workflows/prepare-chat-pack.yml
@@ -1,8 +1,7 @@
 name: Prepare Chat Paste Pack
-
 on:
   push:
-    branches: [main]
+    branches: [ main ]
     paths-ignore:
       - 'CodeForChat/**'
   workflow_dispatch:
@@ -23,16 +22,35 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Build chat packs into CodeForChat/
+      - name: Build chat packs (CodeForChat/)
         run: |
           python -m pip install --upgrade pip
           python tools/make_chat_pack.py
 
+      - name: Show generated files
+        run: |
+          echo "=== CodeForChat tree ==="
+          find CodeForChat -maxdepth 2 -type f | sort || true
+          echo "=== git status ==="
+          git status --porcelain
+
       - name: Commit generated packs to main
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CodeForChat/
-          git diff --cached --quiet || git commit -m "Update Chat Packs [skip ci]"
-          git diff --cached --quiet || git push
+          set -eux
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config user.name  "chat-pack-bot"
+          git config user.email "bot@users.noreply.github.com"
 
+          test -f CodeForChat/factor_pack/chat-pack.txt
+          test -f CodeForChat/drift_pack/chat-pack.txt
+
+          git add -A CodeForChat/ || true
+          git add -f CodeForChat/ || true
+
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(chat): update CodeForChat packs [skip ci]"
+            git pull --rebase origin main || true
+            git push origin HEAD:main
+          else
+            echo "No changes to commit."
+          fi

--- a/tools/make_chat_pack.py
+++ b/tools/make_chat_pack.py
@@ -2,30 +2,21 @@
 # -*- coding: utf-8 -*-
 """
 make_chat_pack.py
-- リポ内の FILES_GROUPS を読み込み（2パック: factor_pack / drift_pack）
-- 各ファイルに L1.. の行番号を付与
-- 1つの巨大テキストに連結し、指定文字数で安全に分割
-- 出力:
-    CodeForChat/factor_pack/chat-pack.txt
-    CodeForChat/factor_pack/chunks/chunk-XX.txt
-    CodeForChat/drift_pack/chat-pack.txt
-    CodeForChat/drift_pack/chunks/chunk-XX.txt
-    CodeForChat/INDEX.txt（両方の目次）
+- FILES_GROUPS（2パック）を読み込み
+- 各ファイルに L1.. の行番号を付与し連結
+- CodeForChat/<pack>/chat-pack.txt と chunks/ を生成
+- CodeForChat/INDEX.txt（全パック目次）も出力
 """
 
 import os, sys, textwrap, hashlib
 
-# 対象メタ
 OWNER  = "dakara32"
 REPO   = "GPT_Code"
 BRANCH = "main"
 
-# このチャットが扱いやすい1チャンクの最大文字数（必要に応じて 9000–14000）
-CHUNK_SIZE = 12000
+CHUNK_SIZE = 12000  # iPhoneコピペ配慮で ~9k–14k の範囲で可
 
-# === ここがポイント：2種類のパックを定義 ===
 FILES_GROUPS = {
-    # ① factor系
     "factor_pack": [
         "factor.py",
         "scorer.py",
@@ -33,7 +24,6 @@ FILES_GROUPS = {
         "documents/README.md",
         "documents/factor_design.md",
     ],
-    # ② drift系
     "drift_pack": [
         "drift.py",
         ".github/workflows/daily-report.yml",
@@ -57,8 +47,8 @@ def header_block(file_list) -> str:
     # === Chat Paste Pack ===
     # Repo: {OWNER}/{REPO} @ {BRANCH}
     # Files: {', '.join(file_list)}
-    # 使い方: 下のチャンクをこのチャットに順番に貼るだけで、全ソースを把握できます。
-    # 注記: 各ファイルは個別に L1.. の行番号で始まります（ファイルごとにリセット）。
+    # 使い方: 下のチャンクを順に貼ればこのチャットで全体把握できます。
+    # 注記: 各ファイルは個別に L1.. で行番号付与。
     ---
     """)
 
@@ -73,52 +63,41 @@ def make_bundle(file_list) -> str:
     return "\n".join(parts)
 
 def chunkify(s: str, n: int):
-    chunks = []
-    i = 0
-    while i < len(s):
-        chunks.append(s[i:i+n])
-        i += n
-    return chunks
+    return [s[i:i+n] for i in range(0, len(s), n)]
 
 def main():
     root_out = "CodeForChat"
     os.makedirs(root_out, exist_ok=True)
 
-    # グローバルINDEXの見出し
     global_index = ["# Chat Paste Pack Index", ""]
 
     for pack_name, file_list in FILES_GROUPS.items():
         bundle = make_bundle(file_list)
         sha = hashlib.sha1(bundle.encode("utf-8")).hexdigest()[:12]
 
-        pack_dir = os.path.join(root_out, pack_name)
+        pack_dir  = os.path.join(root_out, pack_name)
         chunk_dir = os.path.join(pack_dir, "chunks")
         os.makedirs(chunk_dir, exist_ok=True)
 
-        # フル版
-        pack_path = os.path.join(pack_dir, "chat-pack.txt")
-        with open(pack_path, "w", encoding="utf-8") as w:
+        # full
+        with open(os.path.join(pack_dir, "chat-pack.txt"), "w", encoding="utf-8") as w:
             w.write(bundle)
 
-        # チャンク版（コードフェンス付き）
+        # chunks
         chunks = chunkify(bundle, CHUNK_SIZE)
         local_index = [f"# {pack_name} (SHA:{sha}) / {len(chunks)} chunks", ""]
         for idx, raw in enumerate(chunks, start=1):
-            fname = os.path.join(chunk_dir, f"chunk-{idx:02d}.txt")
-            with open(fname, "w", encoding="utf-8") as w:
+            with open(os.path.join(chunk_dir, f"chunk-{idx:02d}.txt"), "w", encoding="utf-8") as w:
                 w.write(f"```text\n{raw}\n```")
             local_index.append(f"- chunks/chunk-{idx:02d}.txt")
 
         with open(os.path.join(pack_dir, "INDEX.txt"), "w", encoding="utf-8") as w:
             w.write("\n".join(local_index))
 
-        # グローバルINDEXにも登録
-        global_index.append(f"## {pack_name}")
-        global_index.append(f"- {pack_name}/chat-pack.txt")
-        global_index.append(f"- {pack_name}/INDEX.txt")
-        global_index.append("")
+        global_index += [f"## {pack_name}",
+                         f"- {pack_name}/chat-pack.txt",
+                         f"- {pack_name}/INDEX.txt", ""]
 
-    # ルートのINDEX.txt
     with open(os.path.join(root_out, "INDEX.txt"), "w", encoding="utf-8") as w:
         w.write("\n".join(global_index))
 


### PR DESCRIPTION
## Summary
- add make_chat_pack.py to build factor and drift chat packs with line numbers and chunked output
- add GitHub Actions workflow to generate and commit CodeForChat packs on pushes to main

## Testing
- `python tools/make_chat_pack.py`
- `find CodeForChat -maxdepth 3 -type f | sort`

------
https://chatgpt.com/codex/tasks/task_e_68bad125ea90832e8e1e365d675fdfc0