### PR TITLE
ci: persist breadth_state

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -36,3 +36,12 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
         run: python drift.py
+
+      - name: Persist breadth_state.json
+        if: always()
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add results/breadth_state.json || true
+          git commit -m "chore: update breadth_state [skip ci]" || echo "no changes"
+          git push || true


### PR DESCRIPTION
## Summary
- persist `breadth_state.json` in daily workflow after running drift

## Testing
- `python -m pytest >/tmp/pytest.log 2>&1; tail -n 20 /tmp/pytest.log`
- `python -m pip install --quiet yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*


------
https://chatgpt.com/codex/tasks/task_e_68c0e946d96c832e9f0cb8fb4e69499d