### PR TITLE
refactor: remove breadth handling from factor

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -41,14 +41,3 @@ jobs:
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           FIN_THREADS: "8"
         run: python factor.py
-      - name: Persist breadth mode (if changed)
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add results/breadth_state.json || true
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: update breadth_state.json [skip ci]" || true
-            git push || true
-          else
-            echo "No breadth_state.json changes."
-          fi


### PR DESCRIPTION
## Summary
- drop trend template breadth calculations and state handling from factor report
- stop persisting breadth_state.json in weekly workflow; drift now owns this

## Testing
- `python -m py_compile factor.py drift.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0eb630be8832e9263822cbea96975