### PR TITLE
Store raw growth z-score and apply EPS-only penalty

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -597,7 +597,7 @@ class Scorer:
         df_z['SIZE'], df_z['LIQ'] = robust_z(np.log1p(df['MARKET_CAP'])), robust_z(np.log1p(df['ADV60_USD']))
         df_z['QUALITY_F'] = robust_z(0.6*df['FCF_W'] + 0.4*df['ROE_W']).clip(-3.0,3.0)
         df_z['YIELD_F']   = 0.3*df_z['DIV'] + 0.7*df_z['DIV_STREAK']
-        df_z['GROWTH_F']  = robust_z(0.25*df_z['REV']          # ↓0.30→0.25
+        grw_z = robust_z(0.25*df_z['REV']          # ↓0.30→0.25
             + 0.20*df_z['EPS_Q_YOY']
             + 0.15*df_z['REV_Q_YOY']
             + 0.15*df_z['REV_YOY_ACC']
@@ -605,7 +605,8 @@ class Scorer:
             + 0.10*df_z['FCF_MGN']
             + 0.10*df_z['EPS']          # ★追加：黒字優遇／赤字減点
             + 0.05*df_z['REV_ANN_STREAK']
-            - 0.05*df_z['REV_YOY_VAR']).clip(-3.0,3.0)
+            - 0.05*df_z['REV_YOY_VAR'])
+        df_z['GROWTH_F'] = grw_z.clip(-3.0,3.0)
         df_z['MOM_F'] = robust_z(0.40*df_z['RS']
             + 0.15*df_z['TR_str']
             + 0.15*df_z['RS_SLOPE_6W']
@@ -614,13 +615,14 @@ class Scorer:
             + 0.10*df_z['MA200_UP_STREAK_D']).clip(-3.0,3.0)
         df_z['VOL'] = robust_z(df['BETA'])
         df_z.rename(columns={'GROWTH_F':'GRW','MOM_F':'MOM','QUALITY_F':'QAL','YIELD_F':'YLD'}, inplace=True)
+        df_z['GRW_raw'] = df_z['GRW']  # 純粋な成長z（ログ用）
+        df_z['GRW'] = df_z['GRW_raw']  # 表示＆選定に使われるGRW
 
         # --- EPS-only penalty: punish negative EPS (GAAP or nEPS) ---
         eps_any = (df.get('EPS', 0) > 0) | (df.get('nEPS_ttm', 0) > 0)
         PEN_EPS = float(os.getenv("PEN_EPS_FOR_GRW", "0.8"))
         if 'GRW' in df_z.columns:
             red_eps = (~eps_any).astype(float)
-            # Adjust displayed GRW directly based on EPS penalty only (no FCF)
             df_z['GRW'] = (df_z['GRW'] - PEN_EPS * red_eps).clip(-3.0, 3.0)
 
         # === begin: BIO LOSS PENALTY =====================================
@@ -658,7 +660,8 @@ class Scorer:
 
         # --- 重みは cfg を優先（外部があればそれを使用） ---
         # ① 全銘柄で G/D スコアを算出（unmasked）
-        g_score_all = df_z.mul(pd.Series(cfg.weights.g)).sum(axis=1)
+        g_cols = list(pd.Series(cfg.weights.g, dtype=float).index)
+        g_score_all = df_z[g_cols].mul(pd.Series(cfg.weights.g)).sum(axis=1)
 
         d_comp = pd.concat({
             'QAL': df_z['D_QAL'],


### PR DESCRIPTION
## Summary
- Preserve raw growth z-scores as `GRW_raw` and use it as the base for displayed/selected `GRW`
- Apply EPS-only penalty (GAAP or non-GAAP) to growth score with configurable severity
- Ensure composite scoring uses the adjusted `GRW` column explicitly

## Testing
- `pytest -q`
- `python - <<'PY' ... dummy check for GRW penalty ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68c57025d2a0832eafd8c32222b7b762