### PR TITLE
Support candidate ticker list for YF probe

### DIFF
--- a/.github/workflows/yf-health-probe.yml
+++ b/.github/workflows/yf-health-probe.yml
@@ -1,7 +1,24 @@
 name: yf-health-probe
+
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      tickers:
+        description: "監視する銘柄（カンマ or 改行区切り）。空なら data/candidates.txt を使用"
+        required: false
+        default: ""
+      period:
+        description: "取得期間（例: 180d, 600d）"
+        required: false
+        default: "180d"
+      min_len:
+        description: "有効本数の下限"
+        required: false
+        default: "120"
+      max_nan:
+        description: "許容欠損率(0-1)"
+        required: false
+        default: "0.15"
 
 jobs:
   run-probe:
@@ -9,6 +26,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -18,23 +36,35 @@ jobs:
           python -m pip install --upgrade pip
           pip install yfinance pandas requests
 
-      - name: Check secret presence
+      - name: Ensure candidates file exists
+        run: |
+          mkdir -p data
+          if [ ! -f data/candidates.txt ]; then
+            echo "# put your tickers here (one per line)" > data/candidates.txt
+          fi
+          echo "---- candidates.txt ----"
+          sed -n '1,100p' data/candidates.txt || true
+          echo "------------------------"
+
+      - name: Check Slack secret presence
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           if [ -z "${SLACK_WEBHOOK_URL}" ]; then
             echo "::error ::Missing repository secret 'SLACK_WEBHOOK_URL'"
             exit 78
-          else
-            echo "SLACK_WEBHOOK_URL is set (masked)"
           fi
 
-      - name: Run probe
+      - name: Run probe (manual)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          YF_PROBE_PERIOD: "180d"
-          YF_PROBE_MIN_LEN: "120"
-          YF_PROBE_MAX_NAN: "0.15"
+          CAND_TICKERS: ${{ github.event.inputs.tickers }}
+          CAND_FILE: data/candidates.txt
+          YF_PROBE_PERIOD: ${{ github.event.inputs.period }}
+          YF_PROBE_MIN_LEN: ${{ github.event.inputs.min_len }}
+          YF_PROBE_MAX_NAN: ${{ github.event.inputs.max_nan }}
           YF_PROBE_RETRY: "1"
           YF_PROBE_TIMEOUT_MS_WARN: "5000"
-        run: python yf_health_probe.py
+          END_OFFSET_DAYS: "1"
+        run: |
+          python yf_health_probe.py

--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -1,0 +1,9 @@
+# put your tickers here (one per line)
+# lines starting with "#" are ignored
+AAPL
+MSFT
+NVDA
+GOOGL
+AMZN
+META
+TSLA

--- a/yf_health_probe.py
+++ b/yf_health_probe.py
@@ -1,69 +1,162 @@
-import os, time, sys
-import pandas as pd
-import yfinance as yf
-import requests
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
 
-TICKERS = os.getenv("YF_PROBE_TICKERS", "AAPL,MSFT,NVDA,GOOGL,AMZN,META,TSLA").split(",")
-PERIOD  = os.getenv("YF_PROBE_PERIOD", "180d")
+import pandas as pd
+import requests
+import yfinance as yf
+
+
+DEFAULT_FALLBACK = ["AAPL", "MSFT", "NVDA", "GOOGL", "AMZN", "META", "TSLA"]
+PERIOD = os.getenv("YF_PROBE_PERIOD", "180d")
 MIN_LEN = int(os.getenv("YF_PROBE_MIN_LEN", "120"))
 MAX_NAN_RATIO = float(os.getenv("YF_PROBE_MAX_NAN", "0.15"))
 RETRY_ON_EMPTY = int(os.getenv("YF_PROBE_RETRY", "1"))
+TIMEOUT_MS_WARN = int(os.getenv("YF_PROBE_TIMEOUT_MS_WARN", "5000"))
+END_OFFSET_DAYS = int(os.getenv("END_OFFSET_DAYS", "1"))
+
 SLACK_WEBHOOK = (
     os.getenv("SLACK_WEBHOOK_URL")
     or os.getenv("SLACK_WEBHOOK")
     or os.getenv("YF_PROBE_SLACK_WEBHOOK")
 )
-TIMEOUT_MS_WARN = int(os.getenv("YF_PROBE_TIMEOUT_MS_WARN", "5000"))
 
-def per_ticker_retry(px, bad):
-    for t in bad:
+
+def _parse_tickers(text: str) -> list[str]:
+    raw = [x.strip().upper() for x in text.replace(",", "\n").splitlines()]
+    return [t for t in raw if t and not t.startswith("#")]
+
+
+def load_candidates() -> list[str]:
+    env_list = os.getenv("CAND_TICKERS", "").strip()
+    if env_list:
+        tickers = _parse_tickers(env_list)
+        if tickers:
+            return tickers
+
+    path = os.getenv("CAND_FILE", "data/candidates.txt")
+    if os.path.exists(path):
         try:
-            h = yf.Ticker(t).history(period=PERIOD, auto_adjust=True)["Close"].rename(t)
-            if not h.dropna().empty:
-                px[t] = h.reindex(px.index) if len(px.index) else h
-        except Exception: 
+            with open(path, "r", encoding="utf-8") as fh:
+                tickers = _parse_tickers(fh.read())
+                if tickers:
+                    return tickers
+        except Exception:
+            pass
+
+    return DEFAULT_FALLBACK
+
+
+def per_ticker_retry(px: pd.DataFrame, tickers: list[str]) -> pd.DataFrame:
+    for ticker in tickers:
+        try:
+            history = (
+                yf.Ticker(ticker)
+                .history(period=PERIOD, auto_adjust=True)["Close"]
+                .rename(ticker)
+            )
+            if not history.dropna().empty:
+                px[ticker] = history.reindex(px.index) if len(px.index) else history
+        except Exception:
             pass
     return px
 
-def assess(px):
-    details, good = [], 0
-    for t in TICKERS:
-        if t not in px.columns:
-            details.append(f"{t}:NF"); continue
-        s = px[t]; n = s.shape[0]; nn = s.notna().sum()
-        nan_ratio = 1.0 - (nn/n if n else 0.0)
-        head_nan = next((i for i,v in enumerate(s) if pd.notna(v)), len(s))
-        tail_nan = next((i for i,v in enumerate(reversed(s.tolist())) if pd.notna(v)), len(s))
+
+def assess(px: pd.DataFrame, tickers: list[str]):
+    details: list[str] = []
+    good = 0
+    for ticker in tickers:
+        if ticker not in px.columns:
+            details.append(f"{ticker}:NF")
+            continue
+
+        series = px[ticker]
+        total = series.shape[0]
+        non_nan = series.notna().sum()
+        nan_ratio = 1.0 - (non_nan / total if total else 0.0)
+        head_nan = next((i for i, v in enumerate(series) if pd.notna(v)), len(series))
+        tail_nan = next(
+            (i for i, v in enumerate(reversed(series.tolist())) if pd.notna(v)),
+            len(series),
+        )
+
         status = "OK"
-        if nn==0: status="EMPTY"
-        elif nn<MIN_LEN or nan_ratio>MAX_NAN_RATIO or head_nan>5 or tail_nan>5: status="BAD"
-        if status=="OK": good+=1
-        details.append(f"{t}:{status}(len={nn},nan={nan_ratio:.2f})")
-    ok_ratio = good/len(TICKERS)
-    if good==len(TICKERS): return 0,"HEALTHY","✅",details
-    elif ok_ratio>=0.5: return 10,"DEGRADED","⚠️",details
-    else: return 20,"DOWN","🛑",details
+        if non_nan == 0:
+            status = "EMPTY"
+        elif (
+            non_nan < MIN_LEN
+            or nan_ratio > MAX_NAN_RATIO
+            or head_nan > 5
+            or tail_nan > 5
+        ):
+            status = "BAD"
 
-def send_slack(text):
+        if status == "OK":
+            good += 1
+
+        details.append(f"{ticker}:{status}(len={non_nan},nan={nan_ratio:.2f})")
+
+    ok_ratio = good / len(tickers) if tickers else 0.0
+    if good == len(tickers):
+        return 0, "HEALTHY", "✅", details
+    if ok_ratio >= 0.5:
+        return 10, "DEGRADED", "⚠️", details
+    return 20, "DOWN", "🛑", details
+
+
+def send_slack(text: str) -> None:
     if not SLACK_WEBHOOK:
-        print("[SLACK] Missing webhook. Set 'SLACK_WEBHOOK_URL' (preferred) or 'SLACK_WEBHOOK'.")
+        print("[SLACK] Missing webhook. Set 'SLACK_WEBHOOK_URL' (preferred).")
         sys.exit(78)
-    try:
-        r = requests.post(SLACK_WEBHOOK, json={"text": text}, timeout=5)
-        print(f"[SLACK] status={r.status_code}")
-        r.raise_for_status()
-    except Exception as e:
-        print(f"[SLACK] send error: {e}")
 
-def main():
-    t0=time.time()
-    data=yf.download(TICKERS,period=PERIOD,auto_adjust=True,progress=False,threads=True)
-    close=data["Close"] if isinstance(data,pd.DataFrame) and "Close" in data else pd.DataFrame()
-    bad=[t for t in TICKERS if (t not in close.columns) or close.get(t,pd.Series(dtype=float)).dropna().empty]
-    if bad and RETRY_ON_EMPTY: close=per_ticker_retry(close,bad)
-    code,level,emoji,details=assess(close)
-    latency=int((time.time()-t0)*1000); speed="🚀" if latency<TIMEOUT_MS_WARN else "🐢"
-    summary=f"{emoji} YF_HEALTH {level} ok={len([d for d in details if 'OK' in d])}/{len(TICKERS)} latency={latency}ms {speed}\n" + " | ".join(details)
-    print(summary); send_slack(summary); sys.exit(code)
+    response = requests.post(SLACK_WEBHOOK, json={"text": text}, timeout=5)
+    print(f"[SLACK] status={response.status_code}")
+    response.raise_for_status()
 
-if __name__=="__main__": main()
+
+def main() -> None:
+    tickers = load_candidates()
+    if not tickers:
+        print("[ERR] no tickers")
+        sys.exit(78)
+
+    start = time.time()
+
+    kwargs = dict(period=PERIOD, auto_adjust=True, progress=False, threads=True)
+    if END_OFFSET_DAYS > 0:
+        kwargs["end"] = (
+            datetime.now(timezone.utc) - timedelta(days=END_OFFSET_DAYS)
+        ).date()
+
+    data = yf.download(tickers, **kwargs)
+    if isinstance(data, pd.DataFrame) and "Close" in data:
+        close = data["Close"]
+    else:
+        close = pd.DataFrame()
+
+    bad = [
+        ticker
+        for ticker in tickers
+        if (ticker not in close.columns)
+        or close.get(ticker, pd.Series(dtype=float)).dropna().empty
+    ]
+    if bad and RETRY_ON_EMPTY:
+        close = per_ticker_retry(close, bad)
+
+    code, level, emoji, details = assess(close, tickers)
+    latency = int((time.time() - start) * 1000)
+    ok_count = sum(1 for detail in details if ":OK(" in detail)
+    speed = "🚀" if latency < TIMEOUT_MS_WARN else "🐢"
+    summary = (
+        f"{emoji} YF_HEALTH {level} ok={ok_count}/{len(tickers)} latency={latency}ms {speed}\n"
+        + " | ".join(details)
+    )
+
+    print(summary)
+    send_slack(summary)
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow the Yahoo Finance health probe to source its tickers from workflow inputs, an optional data/candidates.txt file, or the Magnificent 7 fallback
- tighten Slack webhook handling and add an end-date offset when downloading prices
- add a manual-only GitHub Actions workflow that prepares the candidate list file before running the probe

## Testing
- python -m compileall yf_health_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68c8f047ef6c832ea6586457eb76827f