### PR TITLE
Move YF health probe script into tools

### DIFF
--- a/.github/workflows/yf-health-probe.yml
+++ b/.github/workflows/yf-health-probe.yml
@@ -36,7 +36,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install yfinance pandas requests
 
-      - name: Ensure candidates file exists
+      - name: Ensure candidates file
         run: |
           mkdir -p data
           if [ ! -f data/candidates.txt ]; then
@@ -49,15 +49,19 @@ jobs:
       - name: Check Slack secret presence
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          YF_PROBE_SLACK_WEBHOOK: ${{ secrets.YF_PROBE_SLACK_WEBHOOK }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
-            echo "::error ::Missing repository secret 'SLACK_WEBHOOK_URL'"
+          if [ -z "${SLACK_WEBHOOK_URL}" ] && [ -z "${SLACK_WEBHOOK}" ] && [ -z "${YF_PROBE_SLACK_WEBHOOK}" ]; then
+            echo "::error ::Missing repository secret 'SLACK_WEBHOOK_URL' (or fallbacks 'SLACK_WEBHOOK', 'YF_PROBE_SLACK_WEBHOOK')"
             exit 78
           fi
 
       - name: Run probe (manual)
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          YF_PROBE_SLACK_WEBHOOK: ${{ secrets.YF_PROBE_SLACK_WEBHOOK }}
           CAND_TICKERS: ${{ github.event.inputs.tickers }}
           CAND_FILE: data/candidates.txt
           YF_PROBE_PERIOD: ${{ github.event.inputs.period }}
@@ -67,4 +71,4 @@ jobs:
           YF_PROBE_TIMEOUT_MS_WARN: "5000"
           END_OFFSET_DAYS: "1"
         run: |
-          python yf_health_probe.py
+          python tools/yf_health_probe.py

--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -1,9 +1,8 @@
-# put your tickers here (one per line)
-# lines starting with "#" are ignored
-AAPL
-MSFT
-NVDA
-GOOGL
-AMZN
-META
-TSLA
+# put candidate tickers here (one per line)
+# AAPL
+# MSFT
+# NVDA
+# GOOGL
+# AMZN
+# META
+# TSLA


### PR DESCRIPTION
## Summary
- move the YF health probe script under tools/ and enhance its logging and candidate loading helpers
- add a commented candidate list template and update the manual workflow to call the relocated script with Slack secret fallbacks

## Testing
- python -m compileall tools/yf_health_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68c8f417f5c8832e82046b6c1bf3ab52