### PR TITLE
Enforce candidate-driven YF health probe

### DIFF
--- a/.github/workflows/yf-candidate-health.yml
+++ b/.github/workflows/yf-candidate-health.yml
@@ -1,0 +1,57 @@
+name: yf-candidate-health
+on:
+  workflow_dispatch:
+    inputs:
+      tickers:
+        description: "candidate銘柄（カンマ/改行区切り）。空なら data/candidates.txt を使用"
+        required: false
+        default: ""
+      period:
+        description: "取得期間 (例: 180d, 600d)"
+        required: false
+        default: "180d"
+      min_len:
+        description: "有効本数の下限"
+        required: false
+        default: "120"
+      max_nan:
+        description: "許容欠損率 (0-1)"
+        required: false
+        default: "0.15"
+
+jobs:
+  run-probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install yfinance pandas requests
+      - name: Ensure candidates file
+        run: |
+          mkdir -p data
+          if [ ! -f data/candidates.txt ]; then
+            printf "# placeholder\n" > data/candidates.txt
+          fi
+          sed -n '1,40p' data/candidates.txt || true
+      - name: Check Slack secret
+        env: { SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} }
+        run: |
+          [ -n "${SLACK_WEBHOOK_URL}" ] || (echo "::error ::Missing secret SLACK_WEBHOOK_URL" && exit 78)
+      - name: Run probe (manual; candidate required)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CAND_TICKERS: ${{ github.event.inputs.tickers }}
+          CAND_FILE: data/candidates.txt
+          REQUIRE_CAND: "1"
+          YF_PROBE_PERIOD: ${{ github.event.inputs.period }}
+          YF_PROBE_MIN_LEN: ${{ github.event.inputs.min_len }}
+          YF_PROBE_MAX_NAN: ${{ github.event.inputs.max_nan }}
+          YF_PROBE_RETRY: "1"
+          YF_PROBE_TIMEOUT_MS_WARN: "5000"
+          END_OFFSET_DAYS: "1"
+        run: python tools/yf_health_probe.py


### PR DESCRIPTION
## Summary
- require candidate tickers from env or file and gate execution when none are supplied via `REQUIRE_CAND`
- include the candidate source in probe logging while keeping Slack webhook resolution unchanged
- add a manual `yf-candidate-health` workflow that validates Slack configuration and runs the probe against supplied candidates

## Testing
- python -m compileall tools/yf_health_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68c8fae6de14832e8534c3122c59ab14