### PR TITLE
Update YF health probe candidate handling

### DIFF
--- a/.github/workflows/yf-candidate-health.yml
+++ b/.github/workflows/yf-candidate-health.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       tickers:
-        description: "candidate銘柄（カンマ/改行区切り）。空なら data/candidates.txt を使用"
+        description: "candidate銘柄（カンマ/改行区切り）。空なら candidate_tickers.csv を使用"
         required: false
         default: ""
       period:
@@ -31,13 +31,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install yfinance pandas requests
-      - name: Ensure candidates file
-        run: |
-          mkdir -p data
-          if [ ! -f data/candidates.txt ]; then
-            printf "# placeholder\n" > data/candidates.txt
-          fi
-          sed -n '1,40p' data/candidates.txt || true
       - name: Check Slack secret
         env: { SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} }
         run: |
@@ -46,7 +39,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           CAND_TICKERS: ${{ github.event.inputs.tickers }}
-          CAND_FILE: data/candidates.txt
+          CAND_FILE: candidate_tickers.csv
           REQUIRE_CAND: "1"
           YF_PROBE_PERIOD: ${{ github.event.inputs.period }}
           YF_PROBE_MIN_LEN: ${{ github.event.inputs.min_len }}


### PR DESCRIPTION
## Summary
- prioritize candidate_tickers.csv when loading probe candidates and only fall back to data/candidates.txt when needed
- ensure the health probe exits when no candidate list is supplied while REQUIRE_CAND=1 and tweak status reporting
- update the workflow to use the new candidate resolution behavior and require SLACK_WEBHOOK_URL

## Testing
- python -m compileall tools/yf_health_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68c903875080832e99311a6fc2c14f6e