### PR TITLE
Expand Yahoo Finance health probe coverage

### DIFF
--- a/.github/workflows/yf-health-probe.yml
+++ b/.github/workflows/yf-health-probe.yml
@@ -37,4 +37,4 @@ jobs:
           YF_PROBE_MAX_NAN: "0.15"
           YF_PROBE_RETRY: "1"
           YF_PROBE_TIMEOUT_MS_WARN: "5000"
-        run: python yf_health_probe.py
+        run: python tools/yf_health_probe.py

--- a/tools/yf_health_probe.py
+++ b/tools/yf_health_probe.py
@@ -3,7 +3,13 @@ import pandas as pd
 import yfinance as yf
 import requests
 
-TICKERS = os.getenv("YF_PROBE_TICKERS", "AAPL,MSFT,NVDA,GOOGL,AMZN,META,TSLA").split(",")
+TICKERS = os.getenv(
+    "YF_PROBE_TICKERS",
+    (
+        "AAPL,MSFT,NVDA,GOOGL,AMZN,META,TSLA,BRK-B,JPM,JNJ,V,UNH,XOM,PG,MA,HD,AVGO,"
+        "KO,PEP,MRK,ABBV,COST,CRM,DIS,NFLX,AMD,ORCL,INTC,TSM,NKE"
+    ),
+).split(",")
 PERIOD  = os.getenv("YF_PROBE_PERIOD", "180d")
 MIN_LEN = int(os.getenv("YF_PROBE_MIN_LEN", "120"))
 MAX_NAN_RATIO = float(os.getenv("YF_PROBE_MAX_NAN", "0.15"))


### PR DESCRIPTION
## Summary
- expand the default Yahoo Finance health probe universe to 30 tickers spanning more sectors
- relocate the `yf_health_probe.py` script under `tools/` and update the workflow to call the new path

## Testing
- python -m compileall tools/yf_health_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68c91bbb0624832ebefc61881fc4e01f