### PR TITLE
Improve tr_str robustness to NaNs

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -141,8 +141,15 @@ class Scorer:
 
     @staticmethod
     def tr_str(s):
-        if len(s)<50: return np.nan
-        return s.iloc[-1]/s.rolling(50).mean().iloc[-1] - 1
+        if s is None:
+            return np.nan
+        s = s.ffill(limit=2).dropna()
+        if len(s) < 50:
+            return np.nan
+        ma50 = s.rolling(50, min_periods=50).mean()
+        last_ma = ma50.iloc[-1]
+        last_px = s.iloc[-1]
+        return float(last_px/last_ma - 1.0) if pd.notna(last_ma) and pd.notna(last_px) else np.nan
 
     @staticmethod
     def rs_line_slope(s: pd.Series, b: pd.Series, win: int) -> float:


### PR DESCRIPTION
## Summary
- make tr_str resilient to NaNs by forward-filling limited gaps, dropping missing values, and requiring a full 50-sample window before computing the 50-day average
- return NaN when either the latest price or 50-day average is missing to avoid invalid ratios

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca2415dfb4832e8d2f9f157a801d4d