### PR TITLE
Refine debug table generation with full feature set

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -772,12 +772,18 @@ class Scorer:
         except Exception:
             pass
 
+        df_full = df.copy()
+        df_full_z = df_z.copy()
+
         from factor import FeatureBundle  # type: ignore  # 実行時importなし（循環回避）
         return FeatureBundle(df=df,
             df_z=df_z,
             g_score=g_score,
             d_score_all=d_score_all,
-            missing_logs=pd.DataFrame(missing_logs))
+            missing_logs=pd.DataFrame(missing_logs),
+            df_full=df_full,
+            df_full_z=df_full_z,
+            scaler=None)
 
 def _apply_growth_entry_flags(feature_df, bundle, self_obj, win_breakout=5, win_pullback=5):
     """


### PR DESCRIPTION
## Summary
- add full feature views to the FeatureBundle so downstream consumers can inspect the entire universe
- regenerate the debug table from the full z-scored frame with numeric coercion, ordered tickers, and NaN diagnostics
- streamline debug printing so the formatted table is produced once after display_results and logged for Slack output

## Testing
- python -m compileall factor.py scorer.py

------
https://chatgpt.com/codex/tasks/task_e_68ca3040e3cc832e860b33db5856166a