### PR TITLE
Add soft-fail flag to health probe workflow

### DIFF
--- a/.github/workflows/yf-health-probe.yml
+++ b/.github/workflows/yf-health-probe.yml
@@ -37,4 +37,5 @@ jobs:
           YF_PROBE_MAX_NAN: "0.15"
           YF_PROBE_RETRY: "1"
           YF_PROBE_TIMEOUT_MS_WARN: "5000"
+          YF_PROBE_SOFT_FAIL: "1"
         run: python tools/yf_health_probe.py


### PR DESCRIPTION
## Summary
- add YF_PROBE_SOFT_FAIL to the health probe workflow to allow soft failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca3eda6444832ebcdaff0abd1af439