### PR TITLE
Adjust price data preparation and fills

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -814,6 +814,7 @@ def _apply_growth_entry_flags(feature_df, bundle, self_obj, win_breakout=5, win_
             return feature_df
 
         # 指標
+        px = px.ffill(limit=2)
         ema21 = px[g_universe].ewm(span=21, adjust=False).mean()
         ma50  = px[g_universe].rolling(50).mean()
         ma150 = px[g_universe].rolling(150).mean()


### PR DESCRIPTION
## Summary
- disable yfinance threading and limit forward-filling when preparing price data
- align benchmark closes with price index before downstream calculations
- forward-fill price history before computing breakout and pullback flags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca4788cc00832eb4ec4dae6e4d0bc7