### PR TITLE
Adjust Slack debug sends and gate GRW console dump

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -169,8 +169,12 @@ def _slack_send_text_chunks(url: str, text: str, chunk: int = 2800) -> None:
         except Exception as e:
             print(f"[ERR] debug_post_failed: {e}")
 
-    body = str(text or "")
-    lines = body.splitlines() or [""]
+    body = str(text or "").strip()
+    if not body:
+        print("[DBG] skip debug send: empty body")
+        return
+
+    lines = body.splitlines()
     block: list[str] = []
     block_len = 0
 
@@ -850,12 +854,14 @@ class Output:
         except Exception as e:
             print(f"[ERR] main_post_failed: {e}")
 
-        if debug_mode:
+        if debug_mode and (self.debug_text or "").strip():
             try:
                 requests.post(SLACK_WEBHOOK_URL, json={"text": "```DEBUG (after Low Score)```"})
             except Exception as e:
                 print(f"[ERR] debug_header_failed: {e}")
             _slack_send_text_chunks(SLACK_WEBHOOK_URL, self.debug_text, chunk=2800)
+        else:
+            print(f"[DBG] skip debug send: debug_mode={debug_mode} debug_text_empty={not bool((self.debug_text or '').strip())}")
 
 def _infer_g_universe(feature_df, selected12=None, near5=None):
     try:

--- a/scorer.py
+++ b/scorer.py
@@ -649,6 +649,23 @@ class Scorer:
         df_z['GROWTH_F_RAW'] = grw_combo
         df_z['GROWTH_F'] = robust_z(grw_combo).clip(-3.0, 3.0)
 
+        # Debug dump for GRW composition (console OFF by default; enable only with env)
+        if bool(os.getenv("GRW_CONSOLE_DEBUG")):
+            try:
+                i = df_z[['GROWTH_F', 'GROWTH_F_RAW']].copy()
+                i.sort_values('GROWTH_F', ascending=False, inplace=True)
+                limit = max(0, min(40, len(i)))
+                print("[DEBUG: GRW]")
+                for t in i.index[:limit]:
+                    row = i.loc[t]
+                    parts = [f"GROWTH_F={row['GROWTH_F']:.3f}"]
+                    if pd.notna(row.get('GROWTH_F_RAW')):
+                        parts.append(f"GROWTH_F_RAW={row['GROWTH_F_RAW']:.3f}")
+                    print(f"Ticker: {t} | " + " ".join(parts))
+                print()
+            except Exception as exc:
+                print(f"[ERR] GRW debug dump failed: {exc}")
+
         df_z['MOM_F'] = robust_z(0.40*df_z['RS']
             + 0.15*df_z['TR_str']
             + 0.15*df_z['RS_SLOPE_6W']


### PR DESCRIPTION
## Summary
- avoid sending empty Slack debug messages and log when skipped
- post the Slack debug header only when debug text exists before chunking
- guard the GRW console debug dump behind the `GRW_CONSOLE_DEBUG` environment flag

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caab8f0fb4832ebd7aa6ebac84cf20