### PR TITLE
Remove Slack webhook integration from factor pipeline

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Run factor & scoring
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           FIN_THREADS: "8"
         run: python factor.py


### PR DESCRIPTION
## Summary
- replace Slack webhook helpers in `factor.py` with local debug logging that writes to `results/debug_scores.txt`
- print the factor report, changes, and debug sections directly to stdout while keeping function names compatible
- drop the unused `SLACK_WEBHOOK_URL` secret from the weekly report workflow

## Testing
- `FINNHUB_API_KEY=dummy python factor.py` *(fails: yfinance price fetch blocked by proxy, causing empty price frame)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7a9bc840832e9b841b725a215fd9