### PR TITLE
Log debug details via logger

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -3,7 +3,7 @@
 BONUS_COEFF = 0.55  # 推奨: 攻め=0.45 / 中庸=0.55 / 守り=0.65
 SWAP_DELTA_Z = 0.15   # 僅差判定: σの15%。(緩め=0.10 / 標準=0.15 / 固め=0.20)
 SWAP_KEEP_BUFFER = 3  # n_target+この順位以内の現行は保持。(粘り弱=2 / 標準=3 / 粘り強=4〜5)
-import os, time, requests, sys
+import os, time, requests
 import logging
 from time import perf_counter
 from dataclasses import dataclass
@@ -791,13 +791,12 @@ class Output:
 
             if debug_mode:
                 dt = (self.debug_text or "").strip()
-                print("::group::DEBUG (after Low Score)")
+                logger.info("===== DEBUG (after Low Score) START =====")
                 if dt:
-                    print(dt)
+                    logger.info("\n%s", dt)
                 else:
-                    print("<empty debug_text>")
-                print("::endgroup::")
-                sys.stdout.flush()
+                    logger.info("<empty debug_text>")
+                logger.info("===== DEBUG (after Low Score) END =====")
 
             if not (self.debug_text or "").strip():
                 src_df = df_full or df_full_z_pass or df_z
@@ -819,12 +818,8 @@ class Output:
                     self.debug_text = "(no dataframe)"
         else:
             self.debug_text = ""
-        if debug_mode and (self.debug_text or "").strip():
-            try:
-                logger.info("DEBUG (after Low Score)\n%s", self.debug_text)
-                self._debug_logged = True
-            except Exception as e:
-                print(f"[ERR] debug_log_failed: {e}")
+        if debug_mode:
+            self._debug_logged = True
         else:
             logger.debug(
                 "skip debug log: debug_mode=%s debug_text_empty=%s",


### PR DESCRIPTION
## Summary
- route compact debug output to INFO-level logger instead of stdout when debug mode is enabled
- ensure debug logging occurs even when the compact output is empty and remove unused sys import

## Testing
- python -m compileall factor.py

------
https://chatgpt.com/codex/tasks/task_e_68cbd8b7d65c832ea5a0d304603512fd