### PR TITLE
Add zero ratio summary to df_z dump

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -110,6 +110,22 @@ def _dump_dfz(df_z: pd.DataFrame, debug_mode: bool, max_rows: int = 400, ndigits
         except Exception as exc:
             logger.warning("nan summary failed: %s", exc)
 
+        # === Zeroサマリ（列ごとのゼロ比率 上位20） ===
+        try:
+            zero_counts = ((df_z == 0) & (~df_z.isna())).sum()
+            nonnull_counts = (~df_z.isna()).sum()
+            zero_ratio = (zero_counts / nonnull_counts).sort_values(ascending=False)
+            top_zero = zero_ratio[zero_ratio > 0].head(20)
+            if len(top_zero) > 0:
+                logger.info(
+                    "Zero-dominated columns (top20):\n%s",
+                    top_zero.to_string(float_format=lambda x: f"{x:.2%}"),
+                )
+            else:
+                logger.info("Zero-dominated columns: none")
+        except Exception as exc:
+            logger.warning("zero summary failed: %s", exc)
+
         logger.info("===== DF_Z DUMP START =====")
         logger.info("\n%s", view.to_string(max_rows=None, max_cols=None))
         logger.info("===== DF_Z DUMP END =====")


### PR DESCRIPTION
## Summary
- add zero-ratio logging summary for df_z when debug mode is enabled
- include top 20 zero-dominated columns immediately after the existing NaN summary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc94dd6c94832ea3c060c6f233e6c0