### PR TITLE
Refine factor pipeline structure

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,4 @@
 # 共通設定（factor / drift から参照）
-from dataclasses import dataclass
-
 TOTAL_TARGETS = 20
 
 # 基準のバケット数（NORMAL）

--- a/scorer.py
+++ b/scorer.py
@@ -26,10 +26,7 @@
 # ※入出力の形式・例外文言は既存実装を変えません（安全な短縮のみ）
 # =============================================================================
 
-import logging
-import os, sys, warnings
-import json
-import requests
+import json, logging, os, requests, sys, warnings
 import numpy as np
 import pandas as pd
 import yfinance as yf


### PR DESCRIPTION
## Summary
- consolidate imports and logging setup while simplifying the timer helper
- streamline Slack chunking, selection helpers, SEC fetch utilities, and price preparation without altering behaviour
- trim unused config import and collapse scorer imports for brevity

## Testing
- python factor.py *(fails: environment blocked external data sources and lacks FINNHUB_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68cd43af8770832e9a31cf6cc039f149