### PR TITLE
Ensure sum respects NaNs in scorer weights

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -1004,7 +1004,9 @@ class Scorer:
 
         # --- 重みは cfg を優先（外部があればそれを使用） ---
         # ① 全銘柄で G/D スコアを算出（unmasked）
-        g_score_all = _as_numeric_series(df_z.mul(pd.Series(cfg.weights.g)).sum(axis=1))
+        g_score_all = _as_numeric_series(
+            df_z.mul(pd.Series(cfg.weights.g)).sum(axis=1, skipna=False)
+        )
 
         d_comp = pd.concat({
             'QAL': df_z['D_QAL'],
@@ -1014,7 +1016,9 @@ class Scorer:
         }, axis=1)
         dw = pd.Series(cfg.weights.d, dtype=float).reindex(['QAL','YLD','VOL','TRD']).fillna(0.0)
         globals()['D_WEIGHTS_EFF'] = dw.copy()
-        d_score_all = _as_numeric_series(d_comp.mul(dw, axis=1).sum(axis=1))
+        d_score_all = _as_numeric_series(
+            d_comp.mul(dw, axis=1).sum(axis=1, skipna=False)
+        )
 
         # ② テンプレ判定（既存ロジックそのまま）
         mask = df['trend_template']


### PR DESCRIPTION
## Summary
- ensure G score aggregation respects NaN handling by disabling skipna when summing weighted factors
- apply the same non-skipping behaviour to D score calculations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cffe14d32c832ebac4b5f9c6bc60c3