### PR TITLE
Adjust factor constants, missing data output, and GRW detail logging

### DIFF
--- a/scorer.py
+++ b/scorer.py
@@ -922,11 +922,12 @@ class Scorer:
         df_z['GROWTH_F'] = grw_series
         df_z['GRW_FLEX_WEIGHT'] = 1.0  # 現状は固定（SECの可用性に依らず）
 
-        if str(os.environ.get("GRW_DBG_DETAIL", "0")).strip().lower() in {"1", "true", "yes", "on"}:
+        if 'GRW_Q_RAW' in df.columns:
             df_z['GRW_Q_DBG'] = pd.Series(df['GRW_Q_RAW'], index=df.index, dtype=float)
+        if 'GRW_A_RAW' in df.columns:
             df_z['GRW_A_DBG'] = pd.Series(df['GRW_A_RAW'], index=df.index, dtype=float)
-            df_z['GRW_WQ_DBG'] = wq_series
-            df_z['GRW_WA_DBG'] = wa_series
+        df_z['GRW_WQ_DBG'] = wq_series
+        df_z['GRW_WA_DBG'] = wa_series
 
         df_z['MOM_F'] = robust_z(0.40*df_z['RS']
             + 0.15*df_z['TR_str']


### PR DESCRIPTION
## Summary
- regrouped factor constants/DTOs near the imports, changed the default D beta filter to -0.8, and preserved timing logs
- unified the Missing Data output to a single code-block presentation in console and Slack notifications
- ensured df_z always carries GRW source and weight details regardless of environment flags

## Testing
- python -m compileall factor.py scorer.py

------
https://chatgpt.com/codex/tasks/task_e_68d0a9e8358c832eb6f18eda902f80b0