### PR TITLE
Update API health probe and workflow

### DIFF
--- a/.github/workflows/api-health.yml
+++ b/.github/workflows/api-health.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Show repo tree (CSV check)
         run: |
-          echo "== ls -R for quick CSV check =="
-          ls -R | head -n 300
-          echo "== grep probable csv files =="
+          echo "== ls -R (top 300 lines) =="
+          ls -R | head -n 300 || true
+          echo "== probable csv files =="
           (git ls-files | grep -Ei '(current|candidate).*\.csv$' || true)
       - uses: actions/setup-python@v5
         with:
@@ -26,14 +26,17 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           FINNHUB_API_KEY:   ${{ secrets.FINNHUB_API_KEY }}
-          SEC_EMAIL:         ${{ secrets.SEC_EMAIL }}
-          # 上書きしたい場合だけ指定（例: CSV_CURRENT: data/current.csv）
-          # CSV_CURRENT:       current.csv
-          # CSV_CANDIDATE:     candidate.csv
+          # SECメールは選定と同じ名前のシークレット（SEC_CONTACT_EMAIL）から渡す
+          SEC_CONTACT_EMAIL: ${{ secrets.SEC_CONTACT_EMAIL }}
+          # 判定: DOWN のときだけ失敗（DEGRADEDは成功）
+          EXIT_ON_LEVEL:     DOWN
+          # 任意のパラメータ（必要に応じて）
           YF_PERIOD:         1y
           YF_MIN_LEN:        "120"
           TIMEOUT_MS_WARN:   "5000"
           SOFT_FAIL:         "0"
-          EXIT_ON_LEVEL:     DOWN
         run: |
           python tools/api_health_probe.py
+      - name: Mark job outcome
+        if: always()
+        run: echo "Done."


### PR DESCRIPTION
## Summary
- replace the API health probe with the new implementation that reports icons, SEC contact handling, weird tickers, and optional Finnhub logic
- update the api-health workflow to pass SEC_CONTACT_EMAIL, adjust logging, and only fail when APIs are DOWN

## Testing
- python -m compileall tools/api_health_probe.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b78dfe2c832eaf4711501340c273