### PR TITLE
Adjust bucket update invocation

### DIFF
--- a/factor.py
+++ b/factor.py
@@ -1586,11 +1586,12 @@ def run_pipeline() -> SelectionBundle:
               "sum_score": sumD, "objective": objD},
         top_G=top_G, top_D=top_D, init_G=top_G, init_D=top_D)
 
-    # [ADD] 選定確定後に current_tickers.csv の bucket を最新化
+    # [ADD] G/D選定結果で current_tickers.csv の bucket を部分上書き
     try:
-        _update_bucket_by_selection("current_tickers.csv", sb.top_G, sb.top_D)
+        _update_bucket_by_selection("current_tickers.csv", top_G, top_D)
     except Exception as e:
-        logging.warning("bucket update failed: %s", e)
+        logging.warning("bucket update skipped: %s", e)
+        # 失敗しても本処理は継続（I/O都合で安全側）
 
     # --- Low Score Candidates (GSC+DSC bottom 10) : send before debug dump ---
     try:


### PR DESCRIPTION
## Summary
- update the bucket refresh comment to emphasize partial overwrite after G/D selection
- call the bucket updater with the current selection lists and relax logging on failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6236c9138832eaa2153ff1bf1fadb