### PR TITLE
chore: harden weekly report workflow pushes

### DIFF
--- a/.github/workflows/weekly-report.yml
+++ b/.github/workflows/weekly-report.yml
@@ -20,7 +20,10 @@ jobs:
         run: echo '🚀 DEBUGstarted'
               
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -42,14 +45,28 @@ jobs:
           FIN_THREADS: "8"
           SEC_CONTACT_EMAIL: ${{ secrets.SEC_CONTACT_EMAIL }}
         run: python factor.py
-      - name: Commit current_tickers.csv if changed
+
+      - name: Commit & push current_tickers.csv (rebase-safe)
+        shell: bash
         run: |
-          git config user.name "github-actions[bot]"
+          set -euo pipefail
+          BR="${GITHUB_REF_NAME:-main}"
+
+          git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config pull.rebase true
+          git config --global --add safe.directory "$PWD"
+
           if [[ -n "$(git status --porcelain current_tickers.csv)" ]]; then
             git add current_tickers.csv
-            git commit -m "chore: update current_tickers.csv bucket ($(date -u +'%Y-%m-%dT%H:%M:%SZ'))"
-            git push
+            git commit -m "chore: update current_tickers.csv bucket ($(date -u +'%Y-%m-%dT%H:%M:%SZ'))" || true
+
+            git fetch origin "$BR" --prune
+            git pull --rebase origin "$BR" || true
+
+            if ! git push origin "HEAD:$BR"; then
+              git push --force-with-lease origin "HEAD:$BR"
+            fi
           else
             echo "No changes in current_tickers.csv"
           fi


### PR DESCRIPTION
## Summary
- check out the repository with full history so the workflow can pull and rebase
- update the current_tickers.csv commit step to use a rebase-safe push sequence with force-with-lease fallback

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d62d11b970832ea08437d4fd130426