### PR TITLE
Add integrated TS summary and audit logging

### DIFF
--- a/results/ts_eod_audit.csv
+++ b/results/ts_eod_audit.csv
@@ -1,0 +1,1 @@
+date,symbol,high60,low_today,baseTS,threshold,breach


### PR DESCRIPTION
## Summary
- prepend the combined Growth TS/Breadth section (with G count) to the existing Slack status block
- log each G symbol's EOD evaluation details to results/ts_eod_audit.csv for auditability
- refresh TS logging utilities to maintain the 5D unique count without legacy ts_* files

## Testing
- python -m compileall drift.py

------
https://chatgpt.com/codex/tasks/task_e_68d64b76d318832ea7148723ad0d3b6b