### PR TITLE
Log TS audit results to stdout

### DIFF
--- a/results/ts_eod_audit.csv
+++ b/results/ts_eod_audit.csv
@@ -1,1 +1,0 @@
-date,symbol,high60,low_today,baseTS,threshold,breach


### PR DESCRIPTION
## Summary
- remove the ts_eod_audit.csv writer and stop creating the file
- print the TS audit summary and per-symbol details to stdout with an AUDIT_PRINT_MAX limit
- add warnings for empty datasets so operators know why the audit list is blank

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65b2b57d4832eb8f19bf99d6f0cbd