### PR TITLE
Update daily report workflow to push results automatically

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -9,6 +9,9 @@ on:
     - cron: '30 23 * * 2-6'  # UTC 23:30 → JST 08:30（火〜土）
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-report:
     runs-on: ubuntu-latest
@@ -18,7 +21,9 @@ jobs:
         run: echo '🚀 DEBUGstarted'
               
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -37,11 +42,16 @@ jobs:
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
         run: python drift.py
 
-      - name: Persist breadth_state.json
-        if: always()
+      - name: Commit results if changed
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add results/breadth_state.json || true
-          git commit -m "chore: update breadth_state [skip ci]" || echo "no changes"
-          git push || true
+          git add results/ || true
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git pull --rebase --autostash origin "${GITHUB_REF_NAME:-$GITHUB_REF}" || true
+          git commit -m "ci: update results [skip ci]"
+          git push origin HEAD:${GITHUB_REF_NAME:-$GITHUB_REF}


### PR DESCRIPTION
## Summary
- grant the workflow write access to repository contents
- fetch full history during checkout to support pushing back to the branch
- replace the breadth_state commit step with a conditional push of updated results files

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d74a671e50832ea3952ea77df8296c