### PR TITLE
Fix daily report workflow commit handling

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -45,9 +45,10 @@ jobs:
       - name: Commit results if changed
         if: ${{ github.event_name != 'pull_request' }}
         run: |
+          set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add results/ || true
+          git add -A results/
           if git diff --cached --quiet; then
             echo "No changes to commit."
             exit 0


### PR DESCRIPTION
## Summary
- stage result updates and deletions in the daily-report workflow using `git add -A`
- exit cleanly when no changes are staged while keeping strict shell options enabled

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d79ea39cac832ea6f7c0c20f5e8db8