### PR TITLE
Fix daily report workflow commit sequence

### DIFF
--- a/.github/workflows/daily-report.yml
+++ b/.github/workflows/daily-report.yml
@@ -48,11 +48,17 @@ jobs:
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # 1) 先に最新を取り込む（ローカル変更は autostash に退避→適用）
+          git pull --rebase --autostash origin "${GITHUB_REF_NAME:-$GITHUB_REF}" || true
+          # 2) 万一のフラグ解除（tracked だが add できないケースの保険）
+          git update-index --no-assume-unchanged --no-skip-worktree results/current_mode.json || true
+          # 3) 変更をステージ
           git add -A results/
+          # 4) ステージに差分がなければ正常終了
           if git diff --cached --quiet; then
             echo "No changes to commit."
             exit 0
           fi
-          git pull --rebase --autostash origin "${GITHUB_REF_NAME:-$GITHUB_REF}" || true
+          # 5) コミット→プッシュ
           git commit -m "ci: update results [skip ci]"
           git push origin HEAD:${GITHUB_REF_NAME:-$GITHUB_REF}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc


### PR DESCRIPTION
## Summary
- pull with rebase/autostash before staging to avoid losing staged changes
- clear assume-unchanged flags before staging and keep __pycache__ ignored

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7aa21c394832e8ae014782c359441